### PR TITLE
Allow alignments to have clipping operations in the CIGAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ rMATS will first process the FASTQ input into BAM files stored in the `--tmp` di
 
 #### Starting with BAM files
 
-Reads can be mapped independently of rMATS with any aligner and then the resulting BAM files can be used as input to rMATS.
+Reads can be mapped independently of rMATS with any aligner and then the resulting BAM files can be used as input to rMATS. rMATS requires aligned reads to match --readLength unless --variable-read-length is given. rMATS also ignores alignments with soft or hard clipping unless --allow-clipping is given.
 
 Suppose there are 2 sample groups with 2 BAM files per group.
 
@@ -305,6 +305,7 @@ optional arguments:
                         behavior. Default: 50
   --mel MEL             Maximum Exon Length. Only impacts --novelSS behavior.
                         Default: 500
+  --allow-clipping      Allow alignments with soft or hard clipping to be used
 ```
 
 ## Output

--- a/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
+++ b/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
@@ -56,7 +56,8 @@ cdef:
     int READ_NOT_EXPECTED_STRAND = 5
     int READ_EXON_NOT_MATCHED_TO_ANNOTATION = 6
     int READ_JUNCTION_NOT_MATCHED_TO_ANNOTATION = 7
-    int READ_ENUM_VALUE_COUNT = 8
+    int READ_CLIPPED = 8
+    int READ_ENUM_VALUE_COUNT = 9
     vector[string] READ_ENUM_NAMES = [
         "USED",
         "NOT_PAIRED",
@@ -65,7 +66,8 @@ cdef:
         "NOT_EXPECTED_READ_LENGTH",
         "NOT_EXPECTED_STRAND",
         "EXON_NOT_MATCHED_TO_ANNOTATION",
-        "JUNCTION_NOT_MATCHED_TO_ANNOTATION"
+        "JUNCTION_NOT_MATCHED_TO_ANNOTATION",
+        "CLIPPED"
     ]
 
     char* se_template = '%ld\t%s\t%s\t%s\t%c\t%ld\t%ld\t%ld\t%ld\t%ld\t%ld\n'
@@ -281,12 +283,13 @@ cdef int filter_read(const BamAlignment& bread, const cbool& ispaired) nogil:
 
 @boundscheck(False)
 @wraparound(False)
-cdef int is_bam_exonread(const BamAlignment& bread, const int& readLength,
+cdef int is_bam_exonread(const vector[CigarOp]& cigar_data,
+                         const int& readLength,
                          const cbool variable_read_length) nogil:
-    if bread.CigarData.size() != 1 or bread.CigarData[0].Type != 'M':
+    if cigar_data.size() != 1 or cigar_data[0].Type != 'M':
         return READ_NOT_EXPECTED_CIGAR
 
-    if (not variable_read_length) and bread.CigarData[0].Length != readLength:
+    if (not variable_read_length) and cigar_data[0].Length != readLength:
         return READ_NOT_EXPECTED_READ_LENGTH
 
     return READ_USED
@@ -294,7 +297,7 @@ cdef int is_bam_exonread(const BamAlignment& bread, const int& readLength,
 
 @boundscheck(False)
 @wraparound(False)
-cdef int is_bam_multijunc(const BamAlignment& bread,
+cdef int is_bam_multijunc(const vector[CigarOp]& cigar_data,
                           const int readLength,
                           const cbool variable_read_length) nogil:
     """TODO: Docstring for is_bam_multijunc.
@@ -303,7 +306,7 @@ cdef int is_bam_multijunc(const BamAlignment& bread,
     """
     cdef:
         size_t i
-        size_t num = bread.CigarData.size()
+        size_t num = cigar_data.size()
         int length = 0
 
     if num < 3 or num % 2 == 0:
@@ -311,13 +314,13 @@ cdef int is_bam_multijunc(const BamAlignment& bread,
 
     for i in range(num):
         if i % 2 == 1:
-            if bread.CigarData[i].Type != 'N':
+            if cigar_data[i].Type != 'N':
                 return READ_NOT_EXPECTED_CIGAR
         else:
-            if bread.CigarData[i].Type != 'M':
+            if cigar_data[i].Type != 'M':
                 return READ_NOT_EXPECTED_CIGAR
 
-            length += bread.CigarData[i].Length
+            length += cigar_data[i].Length
 
     if (not variable_read_length) and length != readLength:
         return READ_NOT_EXPECTED_READ_LENGTH
@@ -609,6 +612,45 @@ cdef char check_strand(const BamAlignment& bread, const cbool& ispaired, const i
 
 @boundscheck(False)
 @wraparound(False)
+cdef void drop_clipping_info(const BamAlignment& bread,
+                             vector[CigarOp]* no_clip_cigar_data,
+                             cbool* was_clipped,
+                             cbool* invalid_cigar) nogil:
+    cdef:
+        int i = 0
+        int first_non_clip_i = 0
+        int first_trailing_clip_i = 0
+
+    invalid_cigar[0] = False
+    no_clip_cigar_data[0].clear()
+
+    for i in range(bread.CigarData.size()):
+        if bread.CigarData[i].Type == 'S' or bread.CigarData[i].Type == 'H':
+            first_non_clip_i += 1
+            continue
+        else:
+            break
+
+    first_trailing_clip_i = first_non_clip_i
+    for i in range(first_non_clip_i, bread.CigarData.size()):
+        if bread.CigarData[i].Type == 'S' or bread.CigarData[i].Type == 'H':
+            break
+        else:
+            no_clip_cigar_data[0].push_back(bread.CigarData[i])
+            first_trailing_clip_i += 1
+
+    for i in range(first_trailing_clip_i, bread.CigarData.size()):
+        if bread.CigarData[i].Type == 'S' or bread.CigarData[i].Type == 'H':
+            continue
+        else:
+            invalid_cigar[0] = True
+            break
+
+    was_clipped[0] = no_clip_cigar_data[0].size() != bread.CigarData.size()
+
+
+@boundscheck(False)
+@wraparound(False)
 cdef void parse_bam(long fidx, string bam,
                     unordered_map[int,cset[string]]& geneGroup,
                     unordered_map[string,Gene]& genes,
@@ -618,7 +660,7 @@ cdef void parse_bam(long fidx, string bam,
                     unordered_map[string,cmap[string,int]]& multis,
                     cbool issingle, int jld2, int readLength,
                     cbool variable_read_length, int dt, cbool& novelSS,
-                    long& mil, long& mel,
+                    long& mil, long& mel, cbool allow_clipping,
                     vector[int]& read_outcome_counts) nogil:
     """TODO: Docstring for parse_bam.
     :returns: TODO
@@ -646,11 +688,13 @@ cdef void parse_bam(long fidx, string bam,
         char strand
         cbool valid
 
-
     cdef:
         BamReader br
         BamAlignment bread
         RefVector refv
+        vector[CigarOp] cigar_data_after_clipping
+        cbool bread_was_clipped
+        cbool drop_clipping_info_invalid_cigar
 
     if not br.Open(bam):
         with gil:
@@ -666,6 +710,16 @@ cdef void parse_bam(long fidx, string bam,
             refid2str[br.GetReferenceID(refv[i].RefName)] = refv[i].RefName
 
     while br.GetNextAlignment(bread):
+        drop_clipping_info(bread, &cigar_data_after_clipping, &bread_was_clipped,
+                           &drop_clipping_info_invalid_cigar)
+        if drop_clipping_info_invalid_cigar:
+            read_outcome_counts[READ_NOT_EXPECTED_CIGAR] += 1
+            continue
+
+        if bread_was_clipped and not allow_clipping:
+            read_outcome_counts[READ_CLIPPED] += 1
+            continue
+
         filter_outcome = filter_read(bread, ispaired)
         if filter_outcome != READ_USED:
             read_outcome_counts[filter_outcome] += 1
@@ -673,8 +727,10 @@ cdef void parse_bam(long fidx, string bam,
 
         any_exon_match = False
         any_multijunc_match = False
-        exon_outcome = is_bam_exonread(bread, readLength, variable_read_length)
-        multijunc_outcome = is_bam_multijunc(bread, readLength, variable_read_length)
+        exon_outcome = is_bam_exonread(cigar_data_after_clipping, readLength,
+                                       variable_read_length)
+        multijunc_outcome = is_bam_multijunc(cigar_data_after_clipping,
+                                             readLength, variable_read_length)
         if exon_outcome == READ_USED:
             mc = bread.Position + 1 # position (1-based) where alignment starts
 
@@ -683,7 +739,7 @@ cdef void parse_bam(long fidx, string bam,
                 read_outcome_counts[READ_NOT_EXPECTED_STRAND] += 1
                 continue
 
-            mec = mc + bread.CigarData[0].Length - 1
+            mec = mc + cigar_data_after_clipping[0].Length - 1
             bref_name = refid2str[bread.RefID]
 
             visited.clear()
@@ -715,17 +771,18 @@ cdef void parse_bam(long fidx, string bam,
         elif multijunc_outcome == READ_USED:
             mc = bread.Position # position (0-based) where alignment starts
 
-            minAnchor = c_min(bread.CigarData[0].Length, bread.CigarData.back().Length)
+            minAnchor = c_min(cigar_data_after_clipping[0].Length,
+                              cigar_data_after_clipping.back().Length)
             valid = (minAnchor >= rl_jl)
             bref_name = refid2str[bread.RefID]
 
             visited.clear()
             estart = mc
-            for i in range(0, bread.CigarData.size()):
+            for i in range(0, cigar_data_after_clipping.size()):
                 if i%2 == 0:
-                    eend = estart + bread.CigarData[i].Length # 1-based, end of exonic part
+                    eend = estart + cigar_data_after_clipping[i].Length # 1-based, end of exonic part
                 elif i%2 == 1:
-                    estart = eend + bread.CigarData[i].Length# 0-based, start of exonic part
+                    estart = eend + cigar_data_after_clipping[i].Length# 0-based, start of exonic part
                     continue
 
                 for j in range(estart/refer_len, eend/refer_len+1):
@@ -738,7 +795,7 @@ cdef void parse_bam(long fidx, string bam,
                             continue
 
                         visited.insert(deref(cg))
-                        locate_multi(mc, bread.CigarData, rl_jl, ntx, multiread,
+                        locate_multi(mc, cigar_data_after_clipping, rl_jl, ntx, multiread,
                                      genes[deref(cg)], numstr, valid, novelSS,
                                      mil, mel)
 
@@ -827,6 +884,7 @@ cdef void detect_novel(str bams, unordered_map[int,cset[string]]& geneGroup,
         vector[string] vbams = bams.split(',')
         long mil = args.mil
         long mel = args.mel
+        cbool allow_clipping = args.allow_clipping
         vector[vector[int]] read_outcome_counts
 
     dt = args.dt
@@ -846,7 +904,7 @@ cdef void detect_novel(str bams, unordered_map[int,cset[string]]& geneGroup,
     for fidx in prange(vlen, schedule='static', num_threads=nthread, nogil=True):
         parse_bam(fidx, vbams[fidx], geneGroup, genes, supple, novel_juncs[fidx],
                   exons[fidx], multis[fidx], issingle, jld2, readLength,
-                  variable_read_length, dt, novelSS, mil, mel,
+                  variable_read_length, dt, novelSS, mil, mel, allow_clipping,
                   read_outcome_counts[fidx])
 
     output_read_outcomes(read_outcome_counts, vbams, args.tmp)

--- a/rmats.py
+++ b/rmats.py
@@ -59,7 +59,11 @@ def doSTARMapping(args): ## do STAR mapping
                         os.unlink(map_folder)
 
                 os.makedirs(map_folder)
-                cmd = 'STAR --chimSegmentMin 2 --outFilterMismatchNmax 3 --alignEndsType EndToEnd --runThreadN 4 --outSAMstrandField intronMotif --outSAMtype BAM SortedByCoordinate ';
+                cmd = 'STAR --chimSegmentMin 2 --outFilterMismatchNmax 3'
+                if not args.allow_clipping:
+                    cmd += ' --alignEndsType EndToEnd'
+
+                cmd += ' --runThreadN 4 --outSAMstrandField intronMotif --outSAMtype BAM SortedByCoordinate '
                 cmd += '--alignSJDBoverhangMin ' + str(args.tophatAnchor) + ' --alignIntronMax 299999 --genomeDir ' + args.bIndex + ' --sjdbGTFfile ' + args.gtf; 
                 cmd += ' --outFileNamePrefix ' + map_folder + '/ --readFilesIn ';
                 cmd += ' '.join(pair)

--- a/rmats.py
+++ b/rmats.py
@@ -145,6 +145,9 @@ def get_args():
                         help='Minimum Intron Length. Only impacts --novelSS behavior. Default: %(default)s', dest='mil')
     parser.add_argument('--mel', action='store', type=int, default=500,
                         help='Maximum Exon Length. Only impacts --novelSS behavior. Default: %(default)s', dest='mel')
+    parser.add_argument('--allow-clipping', action='store_true',
+                        help='Allow alignments with soft or hard clipping to be used',
+                        dest='allow_clipping')
 
     args = parser.parse_args()
 

--- a/tests/allow_clipping/.gitignore
+++ b/tests/allow_clipping/.gitignore
@@ -1,0 +1,2 @@
+/clipping_allowed/
+/clipping_not_allowed/

--- a/tests/allow_clipping/test.py
+++ b/tests/allow_clipping/test.py
@@ -73,13 +73,19 @@ class AllowClippingBaseTest(tests.base_test.BaseTest):
                               sample_1_replicate_template):
         rep_1_bam_path = sample_1_replicate_template.format(1)
         rep_1_bam = self._create_bam_from_paired_read_coords(
-            rep_1_bam_path, self._chromosome_length, self._read_length,
-            self._paired_read_coords_1_1(), clip=False)
+            rep_1_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_1_1(),
+            clip_length=None)
 
         rep_2_bam_path = sample_1_replicate_template.format(2)
         rep_2_bam = self._create_bam_from_paired_read_coords(
-            rep_2_bam_path, self._chromosome_length, self._read_length,
-            self._paired_read_coords_1_2(), clip=True)
+            rep_2_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_1_2(),
+            clip_length=3)
 
         sample_1_bams = [rep_1_bam, rep_2_bam]
         self._write_bams(sample_1_bams, sample_1_bams_path)
@@ -89,13 +95,19 @@ class AllowClippingBaseTest(tests.base_test.BaseTest):
                               sample_2_replicate_template):
         rep_1_bam_path = sample_2_replicate_template.format(1)
         rep_1_bam = self._create_bam_from_paired_read_coords(
-            rep_1_bam_path, self._chromosome_length, self._read_length,
-            self._paired_read_coords_2_1(), clip=False)
+            rep_1_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_2_1(),
+            clip_length=None)
 
         rep_2_bam_path = sample_2_replicate_template.format(2)
         rep_2_bam = self._create_bam_from_paired_read_coords(
-            rep_2_bam_path, self._chromosome_length, self._read_length,
-            self._paired_read_coords_2_2(), clip=True)
+            rep_2_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_2_2(),
+            clip_length=3)
 
         sample_2_bams = [rep_1_bam, rep_2_bam]
         self._write_bams(sample_2_bams, sample_2_bams_path)

--- a/tests/allow_clipping/test.py
+++ b/tests/allow_clipping/test.py
@@ -1,0 +1,195 @@
+import os.path
+import unittest
+
+import tests.base_test
+import tests.output_parser as output_parser
+import tests.test_config
+import tests.util
+
+
+class AllowClippingBaseTest(tests.base_test.BaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self._test_base_dir = tests.test_config.TEST_BASE_DIR
+        self._test_dir = os.path.join(self._test_base_dir, 'allow_clipping',
+                                      self._sub_test_name())
+        self._generated_input_dir = os.path.join(self._test_dir,
+                                                 'generated_input')
+        self._out_dir = os.path.join(self._test_dir, 'out')
+        self._tmp_dir = os.path.join(self._test_dir, 'tmp')
+        tests.util.recreate_dirs([
+            self._generated_input_dir, self._out_dir, self._tmp_dir,
+            self._command_output_dir()
+        ])
+
+        self._read_type = 'paired'
+        self._read_length = 50
+        self._chromosome_length = 2000
+        self._task = 'both'
+
+        self._sample_1_bams_path = os.path.join(self._generated_input_dir,
+                                                'b1.txt')
+        sample_1_bam_replicate_template = os.path.join(
+            self._generated_input_dir, 'sample_1_rep_{}.bam')
+        self._sample_1_bams = self._create_sample_1_bams(
+            self._sample_1_bams_path, sample_1_bam_replicate_template)
+
+        self._sample_2_bams_path = os.path.join(self._generated_input_dir,
+                                                'b2.txt')
+        sample_2_bam_replicate_template = os.path.join(
+            self._generated_input_dir, 'sample_2_rep_{}.bam')
+        self._sample_2_bams = self._create_sample_2_bams(
+            self._sample_2_bams_path, sample_2_bam_replicate_template)
+
+        self._gtf_path = os.path.join(self._generated_input_dir, 'test.gtf')
+        self._gtf = self._create_gtf_from_transcripts(
+            self._gtf_path, self._exons_by_transcript())
+
+    def _command_output_dir(self):
+        return os.path.join(self._test_dir, 'command_output')
+
+    def _rmats_arguments(self):
+        return [
+            '--b1',
+            self._sample_1_bams_path,
+            '--b2',
+            self._sample_2_bams_path,
+            '--gtf',
+            self._gtf_path,
+            '--od',
+            self._out_dir,
+            '-t',
+            self._read_type,
+            '--readLength',
+            str(self._read_length),
+            '--tmp',
+            self._tmp_dir,
+            '--task',
+            self._task,
+        ]
+
+    def _create_sample_1_bams(self, sample_1_bams_path,
+                              sample_1_replicate_template):
+        rep_1_bam_path = sample_1_replicate_template.format(1)
+        rep_1_bam = self._create_bam_from_paired_read_coords(
+            rep_1_bam_path, self._chromosome_length, self._read_length,
+            self._paired_read_coords_1_1(), clip=False)
+
+        rep_2_bam_path = sample_1_replicate_template.format(2)
+        rep_2_bam = self._create_bam_from_paired_read_coords(
+            rep_2_bam_path, self._chromosome_length, self._read_length,
+            self._paired_read_coords_1_2(), clip=True)
+
+        sample_1_bams = [rep_1_bam, rep_2_bam]
+        self._write_bams(sample_1_bams, sample_1_bams_path)
+        return sample_1_bams
+
+    def _create_sample_2_bams(self, sample_2_bams_path,
+                              sample_2_replicate_template):
+        rep_1_bam_path = sample_2_replicate_template.format(1)
+        rep_1_bam = self._create_bam_from_paired_read_coords(
+            rep_1_bam_path, self._chromosome_length, self._read_length,
+            self._paired_read_coords_2_1(), clip=False)
+
+        rep_2_bam_path = sample_2_replicate_template.format(2)
+        rep_2_bam = self._create_bam_from_paired_read_coords(
+            rep_2_bam_path, self._chromosome_length, self._read_length,
+            self._paired_read_coords_2_2(), clip=True)
+
+        sample_2_bams = [rep_1_bam, rep_2_bam]
+        self._write_bams(sample_2_bams, sample_2_bams_path)
+        return sample_2_bams
+
+    def _exons_by_transcript(self):
+        return [
+            [(1, 100), (201, 300), (401, 500)],
+            [(1, 100), (401, 500)],
+        ]
+
+    def _include_read(self):
+        return ([[81, 100], [201, 300]], [[201, 300]])
+
+    def _skip_read(self):
+        return ([[81, 100], [401, 500]], [[401, 500]])
+
+    def _paired_read_coords_1_1(self):
+        return [
+            self._include_read(),
+            self._skip_read(),
+        ]
+
+    def _paired_read_coords_1_2(self):
+        return [
+            self._include_read(),
+            self._include_read(),
+            self._skip_read(),
+        ]
+
+    def _paired_read_coords_2_1(self):
+        return [
+            self._include_read(),
+            self._skip_read(),
+        ]
+
+    def _paired_read_coords_2_2(self):
+        return [
+            self._include_read(),
+            self._skip_read(),
+            self._skip_read(),
+        ]
+
+
+class ClippingAllowedTest(AllowClippingBaseTest):
+    def _sub_test_name(self):
+        return 'clipping_allowed'
+
+    def test(self):
+        self._run_test()
+
+    def _rmats_arguments(self):
+        arguments = super()._rmats_arguments()
+        arguments.append('--allow-clipping')
+        return arguments
+
+    def _check_results(self):
+        self._check_no_error_results()
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 1)
+        se_mats_jc_row_0 = se_mats_jc_rows[0]
+        self.assertEqual(se_mats_jc_row_0['IJC_SAMPLE_1'], '1,2')
+        self.assertEqual(se_mats_jc_row_0['SJC_SAMPLE_1'], '1,1')
+        self.assertEqual(se_mats_jc_row_0['IJC_SAMPLE_2'], '1,1')
+        self.assertEqual(se_mats_jc_row_0['SJC_SAMPLE_2'], '1,2')
+
+
+class ClippingNotAllowedTest(AllowClippingBaseTest):
+    def _sub_test_name(self):
+        return 'clipping_not_allowed'
+
+    def test(self):
+        self._run_test()
+
+    def _check_results(self):
+        self._check_no_error_results()
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 1)
+        se_mats_jc_row_0 = se_mats_jc_rows[0]
+        self.assertEqual(se_mats_jc_row_0['IJC_SAMPLE_1'], '1,0')
+        self.assertEqual(se_mats_jc_row_0['SJC_SAMPLE_1'], '1,0')
+        self.assertEqual(se_mats_jc_row_0['IJC_SAMPLE_2'], '1,0')
+        self.assertEqual(se_mats_jc_row_0['SJC_SAMPLE_2'], '1,0')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/bam.py
+++ b/tests/bam.py
@@ -96,16 +96,45 @@ class BAM(object):
             f_handle.write('{}\n'.format('\t'.join(sq_values)))
 
 
-def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
-                                 read_length, clip=False):
-    read_1_start = intervals_1[0][0]
-    read_1.start_coord = read_1_start
+def _clip_length_from_cigar_ends(clip_length, cigar):
+    first_op = cigar[0]
+    if first_op[1] != 'M':
+        return 'cannot clip without initial M cigar operation: {}'.format(
+            cigar)
+    if first_op[0] <= clip_length:
+        return 'not enough initial M to clip: {} {}'.format(clip_length, cigar)
+    cigar[0][0] -= clip_length
+    cigar.insert(0, [clip_length, 'H'])
 
-    read_2.is_reversed = True
-    read_2_start = intervals_2[-1][-1]
-    read_1.template_len = (read_2_start - read_1_start) + 1
+    last_op = cigar[-1]
+    if last_op[1] != 'M':
+        return 'cannot clip without trailing M cigar operation: {}'.format(
+            cigar)
+    if last_op[0] <= clip_length:
+        return 'not enough trailing M to clip: {} {}'.format(
+            clip_length, cigar)
 
-    cigar_1 = ''
+    cigar[-1][0] -= clip_length
+    cigar.append([clip_length, 'H'])
+
+    return None
+
+
+def _string_from_cigar_ops(cigar_ops):
+    cigar_s = ''
+    for length, op in cigar_ops:
+        cigar_s += '{}{}'.format(length, op)
+
+    return cigar_s
+
+
+def set_read_pair_from_intervals(read_1,
+                                 read_2,
+                                 intervals_1,
+                                 intervals_2,
+                                 read_length,
+                                 clip_length=None):
+    cigar_1 = list()
     remaining_length = read_length
     prev_end = None
     for start, end in intervals_1:
@@ -114,24 +143,31 @@ def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
 
         if prev_end is not None:
             skip_len = (start - prev_end) - 1
-            cigar_1 += '{}N'.format(skip_len)
+            cigar_1.append([skip_len, 'N'])
 
         length = (end - start) + 1
         if length >= remaining_length:
-            cigar_1 += '{}M'.format(remaining_length)
+            cigar_1.append([remaining_length, 'M'])
             remaining_length = 0
         else:
-            cigar_1 += '{}M'.format(length)
+            cigar_1.append([length, 'M'])
             remaining_length -= length
 
         prev_end = end
 
-    if clip:
-        cigar_1 = '3H{}3H'.format(cigar_1)
+    read_1_start = intervals_1[0][0]
+    if clip_length:
+        read_1_start += clip_length
+        clip_error = _clip_length_from_cigar_ends(clip_length, cigar_1)
+        if clip_error:
+            return clip_error
 
-    read_1.cigar = cigar_1
+    read_1.start_coord = read_1_start
+    read_1.cigar = _string_from_cigar_ops(cigar_1)
 
-    cigar_2 = ''
+    read_2.is_reversed = True
+    read_2_start = None
+    cigar_2 = list()
     remaining_length = read_length
     prev_start = None
     for start, end in reversed(intervals_2):
@@ -140,25 +176,33 @@ def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
 
         if prev_start is not None:
             skip_len = (prev_start - end) - 1
-            cigar_2 = '{}N{}'.format(skip_len, cigar_2)
+            cigar_2.append([skip_len, 'N'])
 
         length = (end - start) + 1
         if length >= remaining_length:
-            read_2.start_coord = end - (remaining_length - 1)
-            cigar_2 = '{}M{}'.format(remaining_length, cigar_2)
+            read_2_start = end - (remaining_length - 1)
+            cigar_2.append([remaining_length, 'M'])
             remaining_length = 0
         else:
-            read_2.start_coord = start
-            cigar_2 = '{}M{}'.format(length, cigar_2)
+            read_2_start = start
+            cigar_2.append([length, 'M'])
             remaining_length -= length
 
         prev_start = start
 
-    if clip:
-        cigar_2 = '3H{}3H'.format(cigar_2)
+    cigar_2.reverse()
+    read_2_end = intervals_2[-1][-1]
+    if clip_length:
+        read_2_start += clip_length
+        read_2_end -= clip_length
+        clip_error = _clip_length_from_cigar_ends(clip_length, cigar_2)
+        if clip_error:
+            return clip_error
 
-    read_2.cigar = cigar_2
+    read_2.start_coord = read_2_start
+    read_2.cigar = _string_from_cigar_ops(cigar_2)
 
+    read_1.template_len = (read_2_end - read_1_start) + 1
     make_read_pair(read_1, read_2)
     return None
 

--- a/tests/bam.py
+++ b/tests/bam.py
@@ -97,7 +97,7 @@ class BAM(object):
 
 
 def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
-                                 read_length):
+                                 read_length, clip=False):
     read_1_start = intervals_1[0][0]
     read_1.start_coord = read_1_start
 
@@ -126,6 +126,9 @@ def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
 
         prev_end = end
 
+    if clip:
+        cigar_1 = '3H{}3H'.format(cigar_1)
+
     read_1.cigar = cigar_1
 
     cigar_2 = ''
@@ -150,6 +153,9 @@ def set_read_pair_from_intervals(read_1, read_2, intervals_1, intervals_2,
             remaining_length -= length
 
         prev_start = start
+
+    if clip:
+        cigar_2 = '3H{}3H'.format(cigar_2)
 
     read_2.cigar = cigar_2
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -86,9 +86,12 @@ class BaseTest(unittest.TestCase):
         self.assertFalse(error)
         return gtf
 
-    def _create_bam_from_paired_read_coords(self, bam_path, chromosome_length,
-                                            read_length, paired_read_coords,
-                                            clip=False):
+    def _create_bam_from_paired_read_coords(self,
+                                            bam_path,
+                                            chromosome_length,
+                                            read_length,
+                                            paired_read_coords,
+                                            clip_length=None):
         bam = tests.bam.BAM()
         bam.path = bam_path
 
@@ -101,8 +104,12 @@ class BaseTest(unittest.TestCase):
             paired_read_1.template_name = tests.util.template_name_str([i])
             paired_read_2 = tests.bam.Read()
             error = tests.bam.set_read_pair_from_intervals(
-                paired_read_1, paired_read_2, read_1_coords, read_2_coords,
-                read_length, clip=clip)
+                paired_read_1,
+                paired_read_2,
+                read_1_coords,
+                read_2_coords,
+                read_length,
+                clip_length=clip_length)
             self.assertFalse(error)
             bam_reads.extend([paired_read_1, paired_read_2])
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -87,7 +87,8 @@ class BaseTest(unittest.TestCase):
         return gtf
 
     def _create_bam_from_paired_read_coords(self, bam_path, chromosome_length,
-                                            read_length, paired_read_coords):
+                                            read_length, paired_read_coords,
+                                            clip=False):
         bam = tests.bam.BAM()
         bam.path = bam_path
 
@@ -101,7 +102,7 @@ class BaseTest(unittest.TestCase):
             paired_read_2 = tests.bam.Read()
             error = tests.bam.set_read_pair_from_intervals(
                 paired_read_1, paired_read_2, read_1_coords, read_2_coords,
-                read_length)
+                read_length, clip=clip)
             self.assertFalse(error)
             bam_reads.extend([paired_read_1, paired_read_2])
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,5 +1,6 @@
 import unittest
 
+import tests.allow_clipping.test as allow_clipping_test
 import tests.alternative_3_splice_site_novel.test as alternative_3_splice_site_novel_test
 import tests.alternative_5_splice_site_novel.test as alternative_5_splice_site_novel_test
 import tests.mutually_exclusive_exons_novel.test as mutually_exclusive_exons_novel_test
@@ -15,6 +16,8 @@ import tests.variable_read_length.test as variable_read_length_test
 def build_test_suite():
     loader = unittest.defaultTestLoader
     suite = unittest.TestSuite()
+    suite.addTest(
+        loader.loadTestsFromModule(allow_clipping_test))
     suite.addTest(
         loader.loadTestsFromModule(alternative_3_splice_site_novel_test))
     suite.addTest(


### PR DESCRIPTION
* Add new parameter: --allow-clipping
* Remove soft and hard clipping info from ends of CIGAR if allowed
* Add READ_CLIPPED as a read outcome for reads ignored due to clipping

Based on this issue: https://github.com/Xinglab/rmats-turbo/issues/39