### PR TITLE
Add separate columns for JC and JCEC total event counts in the summary file

### DIFF
--- a/rMATS_P/summary.py
+++ b/rMATS_P/summary.py
@@ -95,7 +95,7 @@ def count_events(file_path, args):
 
 def summarize(args, output_file_handle):
     headers = [
-        'EventType', 'TotalEvents', 'SignificantEventsJC',
+        'EventType', 'TotalEventsJC', 'TotalEventsJCEC', 'SignificantEventsJC',
         'SigEventsJCSample1HigherInclusion',
         'SigEventsJCSample2HigherInclusion', 'SignificantEventsJCEC',
         'SigEventsJCECSample1HigherInclusion',
@@ -109,10 +109,11 @@ def summarize(args, output_file_handle):
                                  '{}.MATS.JCEC.txt'.format(event))
         jc_event_counts = count_events(jc_path, args)
         jcec_event_counts = count_events(jcec_path, args)
+        jc_total = jc_event_counts['total']
         jcec_total = jcec_event_counts['total']
 
         values = [
-            event, jcec_total, jc_event_counts['sig'],
+            event, jc_total, jcec_total, jc_event_counts['sig'],
             jc_event_counts['sig_sample_1_higher'],
             jc_event_counts['sig_sample_2_higher'], jcec_event_counts['sig'],
             jcec_event_counts['sig_sample_1_higher'],

--- a/rMATS_P/summary.py
+++ b/rMATS_P/summary.py
@@ -109,16 +109,10 @@ def summarize(args, output_file_handle):
                                  '{}.MATS.JCEC.txt'.format(event))
         jc_event_counts = count_events(jc_path, args)
         jcec_event_counts = count_events(jcec_path, args)
-        jc_total = jc_event_counts['total']
         jcec_total = jcec_event_counts['total']
-        if jc_total != jcec_total:
-            print('Total {} event counts should match for JC and JCEC'
-                  ' but saw: JC={}, JCEC={}'.format(event, jc_total,
-                                                    jcec_total),
-                  file=sys.stderr)
 
         values = [
-            event, jc_total, jc_event_counts['sig'],
+            event, jcec_total, jc_event_counts['sig'],
             jc_event_counts['sig_sample_1_higher'],
             jc_event_counts['sig_sample_2_higher'], jcec_event_counts['sig'],
             jcec_event_counts['sig_sample_1_higher'],


### PR DESCRIPTION
* The set of JCEC events may include some events not in the JC
  set. This is because the additional exon counts could allow the
  event to pass the filter

This was seen in: https://github.com/Xinglab/rmats-turbo/issues/59#issuecomment-732058933