### PR TITLE
Consistently check strand for both exon and junction reads

### DIFF
--- a/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
+++ b/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
@@ -667,7 +667,7 @@ cdef void parse_bam(long fidx, string bam,
                     unordered_map[string,Gene]& genes,
                     unordered_map[string,SupInfo]& supple,
                     unordered_map[string,vector[Triad]]& novel_juncs,
-                    unordered_map[string,cmap[Tetrad,pair[int,int]]]& exons,
+                    unordered_map[string,cmap[Tetrad,int]]& exons,
                     unordered_map[string,cmap[string,int]]& multis,
                     cbool issingle, int jld2, int readLength,
                     cbool variable_read_length, int dt, cbool& novelSS,
@@ -678,7 +678,6 @@ cdef void parse_bam(long fidx, string bam,
 
     """
     cdef:
-        cset[pair[int,int]] tmp_set
         cset[string].iterator cg
         cset[string] visited
         cbool ispaired = not issingle
@@ -737,6 +736,11 @@ cdef void parse_bam(long fidx, string bam,
             read_outcome_counts[filter_outcome] += 1
             continue
 
+        strand = check_strand(bread, ispaired, dt)
+        if dt != FRUNSTRANDED and strand == cdot:
+            read_outcome_counts[READ_NOT_EXPECTED_STRAND] += 1
+            continue
+
         any_exon_match = False
         any_multijunc_match = False
         exon_outcome = is_bam_exonread(
@@ -745,14 +749,9 @@ cdef void parse_bam(long fidx, string bam,
         multijunc_outcome = is_bam_multijunc(
             cigar_data_after_clipping, amount_clipped, readLength,
             variable_read_length)
+
         if exon_outcome == READ_USED:
             mc = bread.Position + 1 # position (1-based) where alignment starts
-
-            strand = check_strand(bread, ispaired, dt)
-            if dt != FRUNSTRANDED and strand == cdot:
-                read_outcome_counts[READ_NOT_EXPECTED_STRAND] += 1
-                continue
-
             mec = mc + cigar_data_after_clipping[0].Length - 1
             bref_name = refid2str[bread.RefID]
 
@@ -761,9 +760,10 @@ cdef void parse_bam(long fidx, string bam,
                 cg = geneGroup[i].begin()
                 while cg != geneGroup[i].end():
                     ## for each candidate gene
-
-                    if supple[deref(cg)].chrom != bref_name or\
-                        visited.find(deref(cg)) != visited.end():
+                    if ((supple[deref(cg)].chrom != bref_name
+                         or (supple[deref(cg)].strand != strand
+                             and dt != FRUNSTRANDED)
+                         or visited.find(deref(cg)) != visited.end())):
                         inc(cg)
                         continue
 
@@ -773,12 +773,7 @@ cdef void parse_bam(long fidx, string bam,
                     if (tetrad.first != -1 and tetrad.second != -1) or\
                             (tetrad.third != -1 and tetrad.fourth != -1):
                         any_exon_match = True
-                        if dt == FRUNSTRANDED:
-                            exons[deref(cg)][tetrad].first = exons[deref(cg)][tetrad].first + 1
-                        elif strand == plus_mark:
-                            exons[deref(cg)][tetrad].first = exons[deref(cg)][tetrad].first + 1
-                        elif strand == minus_mark:
-                            exons[deref(cg)][tetrad].second = exons[deref(cg)][tetrad].second + 1
+                        exons[deref(cg)][tetrad] += 1
 
                     inc(cg)
 
@@ -803,8 +798,10 @@ cdef void parse_bam(long fidx, string bam,
                     cg = geneGroup[j].begin()
                     while cg != geneGroup[j].end():
                         ## for each candidate gene
-                        if supple[deref(cg)].chrom != bref_name or\
-                                visited.find(deref(cg)) != visited.end():
+                        if ((supple[deref(cg)].chrom != bref_name
+                             or (supple[deref(cg)].strand != strand
+                                 and dt != FRUNSTRANDED)
+                             or visited.find(deref(cg)) != visited.end())):
                             inc(cg)
                             continue
 
@@ -815,7 +812,7 @@ cdef void parse_bam(long fidx, string bam,
 
                         if multiread.length() > 0:
                             any_multijunc_match = True
-                            multis[deref(cg)][multiread] = multis[deref(cg)][multiread] + 1
+                            multis[deref(cg)][multiread] += 1
                         if ntx.size() != 0:
                             any_multijunc_match = True
                             novel_juncs[deref(cg)].insert(novel_juncs[deref(cg)].begin(),
@@ -884,7 +881,7 @@ cdef void detect_novel(str bams, unordered_map[int,cset[string]]& geneGroup,
                        unordered_map[string,Gene]& genes,
                        unordered_map[string,SupInfo]& supple,
                        vector[unordered_map[string,vector[Triad]]]& novel_juncs,
-                       vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                       vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                        vector[unordered_map[string,cmap[string,int]]]& multis, args):
     """TODO: Docstring for detect_novel.
     :returns: TODO
@@ -1820,17 +1817,17 @@ cdef void detect_ri(const string& gID, Gene& gene, SupInfo& supInfo,
 @boundscheck(False)
 @wraparound(False)
 cdef void count_se(cset[SE_info]& junction_se,
-                   vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                   vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                    vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                    vector[Read_count_table]& jc_se, vector[Read_count_table]& jcec_se,
-                   vector[size_t]& residx, int& dt) nogil:
+                   vector[size_t]& residx) nogil:
     cdef:
-        int idx, count = 0
+        int idx
         size_t i, j, 
         Tetrad tetrad
-        cmap[Tetrad,pair[int,int]].iterator imap2
+        cmap[Tetrad,int].iterator imap2
         cmap[vector[pair[long,long]],int].iterator imap
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iunmap2
+        unordered_map[string,cmap[Tetrad,int]].iterator iunmap2
         unordered_map[string,cmap[vector[pair[long,long]],int]].iterator iunmap
         cset[SE_info].iterator ise = junction_se.begin()
 
@@ -1871,16 +1868,10 @@ cdef void count_se(cset[SE_info]& junction_se,
             if iunmap2 != exons[i].end():
                 imap2 = deref(iunmap2).second.begin()
                 while imap2 != deref(iunmap2).second.end():
-                    if dt == FRUNSTRANDED:
-                        count = deref(imap2).second.first
-                    elif deref(ise).supInfo.strand == plus_mark:
-                        count = deref(imap2).second.first
-                    elif deref(ise).supInfo.strand == minus_mark:
-                        count = deref(imap2).second.second
                     if deref(imap2).first.first > deref(ise).ts and\
                             deref(imap2).first.fourth != -1 and\
                             deref(imap2).first.fourth <= deref(ise).te:
-                        jcec_se[idx].incv[i] += count
+                        jcec_se[idx].incv[i] += deref(imap2).second
                     inc(imap2)
 
         inc(ise)
@@ -1889,17 +1880,17 @@ cdef void count_se(cset[SE_info]& junction_se,
 @boundscheck(False)
 @wraparound(False)
 cdef void count_mxe(cset[MXE_info]& junction_mxe,
-                    vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                    vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                     vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                     vector[Read_count_table]& jc_mxe, vector[Read_count_table]& jcec_mxe,
-                    vector[size_t]& residx, int& dt) nogil:
+                    vector[size_t]& residx) nogil:
     cdef:
-        int idx, count = 0
+        int idx
         size_t i, j
         Tetrad tetrad
-        cmap[Tetrad,pair[int,int]].iterator imap2
+        cmap[Tetrad,int].iterator imap2
         cmap[vector[pair[long,long]],int].iterator imap
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iunmap2
+        unordered_map[string,cmap[Tetrad,int]].iterator iunmap2
         unordered_map[string,cmap[vector[pair[long,long]],int]].iterator iunmap
         cset[MXE_info].iterator imxe = junction_mxe.begin()
 
@@ -1951,20 +1942,14 @@ cdef void count_mxe(cset[MXE_info]& junction_mxe,
             if iunmap2 != exons[i].end():
                 imap2 = deref(iunmap2).second.begin()
                 while imap2 != deref(iunmap2).second.end():
-                    if dt == FRUNSTRANDED:
-                        count = deref(imap2).second.first
-                    elif deref(imxe).supInfo.strand == plus_mark:
-                        count = deref(imap2).second.first
-                    elif deref(imxe).supInfo.strand == minus_mark:
-                        count = deref(imap2).second.second
                     if deref(imap2).first.first > deref(imxe).ts and\
                             deref(imap2).first.fourth != -1 and\
                             deref(imap2).first.fourth <= deref(imxe).te:
-                        jcec_mxe[idx].incv[i] += count
+                        jcec_mxe[idx].incv[i] += deref(imap2).second
                     elif deref(imap2).first.first > deref(imxe).ss and\
                             deref(imap2).first.fourth != -1 and\
                             deref(imap2).first.fourth <= deref(imxe).se:
-                        jcec_mxe[idx].skpv[i] += count
+                        jcec_mxe[idx].skpv[i] += deref(imap2).second
 
                     inc(imap2)
 
@@ -1974,18 +1959,18 @@ cdef void count_mxe(cset[MXE_info]& junction_mxe,
 @boundscheck(False)
 @wraparound(False)
 cdef void count_alt3(cset[ALT35_info]& junction_3,
-                     vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                     vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                      vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                      vector[Read_count_table]& jc_alt3, vector[Read_count_table]& jcec_alt3,
-                     int& jld2, int& rl, vector[size_t]& residx, int& dt) nogil:
+                     int& jld2, int& rl, vector[size_t]& residx) nogil:
     cdef:
-        int idx, count = 0
+        int idx
         size_t i, j
         int rl_jl = rl - jld2
         Tetrad tetrad
-        cmap[Tetrad,pair[int,int]].iterator imap2
+        cmap[Tetrad,int].iterator imap2
         cmap[vector[pair[long,long]],int].iterator imap
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iunmap2
+        unordered_map[string,cmap[Tetrad,int]].iterator iunmap2
         unordered_map[string,cmap[vector[pair[long,long]],int]].iterator iunmap
         cset[ALT35_info].iterator ialt3 = junction_3.begin()
 
@@ -2023,23 +2008,17 @@ cdef void count_alt3(cset[ALT35_info]& junction_3,
                 if iunmap2 != exons[i].end():
                     imap2 = deref(iunmap2).second.begin()
                     while imap2 != deref(iunmap2).second.end():
-                        if dt == FRUNSTRANDED:
-                            count = deref(imap2).second.first
-                        elif deref(ialt3).supInfo.strand == plus_mark:
-                            count = deref(imap2).second.first
-                        elif deref(ialt3).supInfo.strand == minus_mark:
-                            count = deref(imap2).second.second
                         if deref(imap2).first.second <= deref(ialt3).se-rl_jl+1 and\
                                 deref(imap2).first.second != -1 and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt3).le and\
                                 deref(imap2).first.third >= deref(ialt3).se+rl_jl:
-                            jc_alt3[idx].incv[i] += count
-                            jcec_alt3[idx].incv[i] += count
+                            jc_alt3[idx].incv[i] += deref(imap2).second
+                            jcec_alt3[idx].incv[i] += deref(imap2).second
                         if deref(imap2).first.first > deref(ialt3).se and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt3).le:
-                            jcec_alt3[idx].incv[i] += count
+                            jcec_alt3[idx].incv[i] += deref(imap2).second
 
                         inc(imap2)
 
@@ -2074,22 +2053,16 @@ cdef void count_alt3(cset[ALT35_info]& junction_3,
                 if iunmap2 != exons[i].end():
                     imap2 = deref(iunmap2).second.begin()
                     while imap2 != deref(iunmap2).second.end():
-                        if dt == FRUNSTRANDED:
-                            count = deref(imap2).second.first
-                        elif deref(ialt3).supInfo.strand == plus_mark:
-                            count = deref(imap2).second.first
-                        elif deref(ialt3).supInfo.strand == minus_mark:
-                            count = deref(imap2).second.second
                         if deref(imap2).first.first > deref(ialt3).ls and\
                                 deref(imap2).first.second != -1 and\
                                 deref(imap2).first.second <= deref(ialt3).ss-rl_jl+1 and\
                                 deref(imap2).first.third >= deref(ialt3).ss+rl_jl:
-                            jc_alt3[idx].incv[i] += count
-                            jcec_alt3[idx].incv[i] += count
+                            jc_alt3[idx].incv[i] += deref(imap2).second
+                            jcec_alt3[idx].incv[i] += deref(imap2).second
                         if deref(imap2).first.first > deref(ialt3).ls and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt3).ss:
-                            jcec_alt3[idx].incv[i] += count
+                            jcec_alt3[idx].incv[i] += deref(imap2).second
 
                         inc(imap2)
 
@@ -2099,18 +2072,18 @@ cdef void count_alt3(cset[ALT35_info]& junction_3,
 @boundscheck(False)
 @wraparound(False)
 cdef void count_alt5(cset[ALT35_info]& junction_5,
-                     vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                     vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                      vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                      vector[Read_count_table]& jc_alt5, vector[Read_count_table]& jcec_alt5,
-                     int& jld2, int& rl, vector[size_t]& residx, int& dt) nogil:
+                     int& jld2, int& rl, vector[size_t]& residx) nogil:
     cdef:
-        int idx, count = 0
+        int idx
         size_t i, j
         long rl_jl = rl - jld2
         Tetrad tetrad
-        cmap[Tetrad,pair[int,int]].iterator imap2
+        cmap[Tetrad,int].iterator imap2
         cmap[vector[pair[long,long]],int].iterator imap
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iunmap2
+        unordered_map[string,cmap[Tetrad,int]].iterator iunmap2
         unordered_map[string,cmap[vector[pair[long,long]],int]].iterator iunmap
         cset[ALT35_info].iterator ialt5 = junction_5.begin()
 
@@ -2148,23 +2121,17 @@ cdef void count_alt5(cset[ALT35_info]& junction_5,
                 if iunmap2 != exons[i].end():
                     imap2 = deref(iunmap2).second.begin()
                     while imap2 != deref(iunmap2).second.end():
-                        if dt == FRUNSTRANDED:
-                            count = deref(imap2).second.first
-                        elif deref(ialt5).supInfo.strand == plus_mark:
-                            count = deref(imap2).second.first
-                        elif deref(ialt5).supInfo.strand == minus_mark:
-                            count = deref(imap2).second.second
                         if deref(imap2).first.second <= deref(ialt5).se-rl_jl+1 and\
                                 deref(imap2).first.second != -1 and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt5).le and\
                                 deref(imap2).first.third >= deref(ialt5).se+rl_jl:
-                            jc_alt5[idx].incv[i] += count
-                            jcec_alt5[idx].incv[i] += count
+                            jc_alt5[idx].incv[i] += deref(imap2).second
+                            jcec_alt5[idx].incv[i] += deref(imap2).second
                         if deref(imap2).first.first > deref(ialt5).se and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt5).le:
-                            jcec_alt5[idx].incv[i] += count
+                            jcec_alt5[idx].incv[i] += deref(imap2).second
 
                         inc(imap2)
 
@@ -2199,22 +2166,16 @@ cdef void count_alt5(cset[ALT35_info]& junction_5,
                 if iunmap2 != exons[i].end():
                     imap2 = deref(iunmap2).second.begin()
                     while imap2 != deref(iunmap2).second.end():
-                        if dt == FRUNSTRANDED:
-                            count = deref(imap2).second.first
-                        elif deref(ialt5).supInfo.strand == plus_mark:
-                            count = deref(imap2).second.first
-                        elif deref(ialt5).supInfo.strand == minus_mark:
-                            count = deref(imap2).second.second
                         if deref(imap2).first.first > deref(ialt5).ls and\
                                 deref(imap2).first.second != -1 and\
                                 deref(imap2).first.second <= deref(ialt5).ss-rl_jl+1 and\
                                 deref(imap2).first.third >= deref(ialt5).ss+rl_jl:
-                            jc_alt5[idx].incv[i] += count
-                            jcec_alt5[idx].incv[i] += count
+                            jc_alt5[idx].incv[i] += deref(imap2).second
+                            jcec_alt5[idx].incv[i] += deref(imap2).second
                         if deref(imap2).first.first > deref(ialt5).ls and\
                                 deref(imap2).first.fourth != -1 and\
                                 deref(imap2).first.fourth <= deref(ialt5).ss:
-                            jcec_alt5[idx].incv[i] += count
+                            jcec_alt5[idx].incv[i] += deref(imap2).second
 
                         inc(imap2)
 
@@ -2224,18 +2185,18 @@ cdef void count_alt5(cset[ALT35_info]& junction_5,
 @boundscheck(False)
 @wraparound(False)
 cdef void count_ri(cset[RI_info]& junction_ri,
-                   vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                   vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                    vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                    vector[Read_count_table]& jc_ri, vector[Read_count_table]& jcec_ri,
-                   int& jld2, int& rl, vector[size_t]& residx, int& dt) nogil:
+                   int& jld2, int& rl, vector[size_t]& residx) nogil:
     cdef:
-        int idx, count = 0
+        int idx
         size_t i, j
         long rl_jl = rl - jld2
         Tetrad tetrad
-        cmap[Tetrad,pair[int,int]].iterator imap2
+        cmap[Tetrad,int].iterator imap2
         cmap[vector[pair[long,long]],int].iterator imap
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iunmap2
+        unordered_map[string,cmap[Tetrad,int]].iterator iunmap2
         unordered_map[string,cmap[vector[pair[long,long]],int]].iterator iunmap
         cset[RI_info].iterator iri = junction_ri.begin()
 
@@ -2273,12 +2234,6 @@ cdef void count_ri(cset[RI_info]& junction_ri,
                 imap2 = deref(iunmap2).second.begin()
 
                 while imap2 != deref(iunmap2).second.end():
-                    if dt == FRUNSTRANDED:
-                        count = deref(imap2).second.first
-                    elif deref(iri).supInfo.strand == plus_mark:
-                        count = deref(imap2).second.first
-                    elif deref(iri).supInfo.strand == minus_mark:
-                        count = deref(imap2).second.second
                     if (deref(imap2).first.second <= deref(iri).ue-rl_jl+1 and\
                             deref(imap2).first.second != -1 and\
                             deref(imap2).first.third >= deref(iri).ue+rl_jl)\
@@ -2286,12 +2241,12 @@ cdef void count_ri(cset[RI_info]& junction_ri,
                        (deref(imap2).first.second != -1 and\
                             deref(imap2).first.second <= deref(iri).ds-rl_jl+1 and\
                             deref(imap2).first.third >= deref(iri).ds+rl_jl):
-                        jc_ri[idx].incv[i] += count
-                        jcec_ri[idx].incv[i] += count
+                        jc_ri[idx].incv[i] += deref(imap2).second
+                        jcec_ri[idx].incv[i] += deref(imap2).second
                     if deref(imap2).first.first > deref(iri).ue and\
                             deref(imap2).first.fourth != -1 and\
                             deref(imap2).first.fourth <= deref(iri).ds:
-                        jcec_ri[idx].incv[i] += count
+                        jcec_ri[idx].incv[i] += deref(imap2).second
 
                     inc(imap2)
 
@@ -2304,7 +2259,7 @@ cdef count_occurrence(str bams, list dot_rmats_paths, str od,
                       cset[SE_info]& se, cset[MXE_info]& mxe,
                       cset[ALT35_info]& alt3, cset[ALT35_info]& alt5,
                       cset[RI_info]& ri, int sam1len, int& jld2, int& rl,
-                      int& nthread, int& dt, cbool stat):
+                      int& nthread, cbool stat):
     cdef:
         size_t idx = 0
         list vbams = bams.split(',')
@@ -2324,7 +2279,7 @@ cdef count_occurrence(str bams, list dot_rmats_paths, str od,
         vector[Read_count_table] jcec_alt3 = vector[Read_count_table](alt3.size())
         vector[Read_count_table] jcec_alt5 = vector[Read_count_table](alt5.size())
         vector[Read_count_table] jcec_ri = vector[Read_count_table](ri.size())
-        vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]] exons
+        vector[unordered_map[string,cmap[Tetrad,int]]] exons
         vector[unordered_map[string,cmap[vector[pair[long,long]],int]]] juncs
         vector[vector[size_t]] resindice
 
@@ -2404,11 +2359,11 @@ cdef count_occurrence(str bams, list dot_rmats_paths, str od,
         with gil:
             resindice[fidx] = load_read(bams, dot_rmats_paths[fidx], exons, juncs)
 
-        count_se(se, exons, juncs, jc_se, jcec_se, resindice[fidx], dt)
-        count_mxe(mxe, exons, juncs, jc_mxe, jcec_mxe, resindice[fidx], dt)
-        count_alt3(alt3, exons, juncs, jc_alt3, jcec_alt3, jld2, rl, resindice[fidx], dt)
-        count_alt5(alt5, exons, juncs, jc_alt5, jcec_alt5, jld2, rl, resindice[fidx], dt)
-        count_ri(ri, exons, juncs, jc_ri, jcec_ri, jld2, rl, resindice[fidx], dt)
+        count_se(se, exons, juncs, jc_se, jcec_se, resindice[fidx])
+        count_mxe(mxe, exons, juncs, jc_mxe, jcec_mxe, resindice[fidx])
+        count_alt3(alt3, exons, juncs, jc_alt3, jcec_alt3, jld2, rl, resindice[fidx])
+        count_alt5(alt5, exons, juncs, jc_alt5, jcec_alt5, jld2, rl, resindice[fidx])
+        count_ri(ri, exons, juncs, jc_ri, jcec_ri, jld2, rl, resindice[fidx])
 
         for idx in resindice[fidx]:
             exons[idx].clear()
@@ -3000,11 +2955,11 @@ cdef save_nj(fp, unordered_map[string,vector[Triad]]& novel_juncs):
 
 @boundscheck(False)
 @wraparound(False)
-cdef save_exons(fp, unordered_map[string,cmap[Tetrad,pair[int,int]]]& exons):
+cdef save_exons(fp, unordered_map[string,cmap[Tetrad,int]]& exons):
     cdef:
         string line
-        unordered_map[string,cmap[Tetrad,pair[int,int]]].iterator iexons
-        cmap[Tetrad,pair[int,int]].iterator imap
+        unordered_map[string,cmap[Tetrad,int]].iterator iexons
+        cmap[Tetrad,int].iterator imap
 
     line = '%d\n' % (exons.size())
     fp.write(line)
@@ -3014,10 +2969,9 @@ cdef save_exons(fp, unordered_map[string,cmap[Tetrad,pair[int,int]]]& exons):
         line = deref(iexons).first
         imap = deref(iexons).second.begin()
         while imap != deref(iexons).second.end():
-            line = '%s;%d,%d,%d,%d,%d,%d' % (line, deref(imap).first.first,
+            line = '%s;%d,%d,%d,%d,%d' % (line, deref(imap).first.first,
                     deref(imap).first.second, deref(imap).first.third,
-                    deref(imap).first.fourth, deref(imap).second.first,
-                    deref(imap).second.second)
+                    deref(imap).first.fourth, deref(imap).second)
             inc(imap)
 
         fp.write(line)
@@ -3054,7 +3008,7 @@ cdef save_multis(fp, unordered_map[string,cmap[string,int]]& multis):
 cdef save_job(str bams, const string& tmp_dir, str prep_prefix,
               const int& readLength,
               vector[unordered_map[string,vector[Triad]]]& novel_juncs,
-              vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+              vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
               vector[unordered_map[string,cmap[string,int]]]& multis):
     cdef:
         int bam_i
@@ -3096,7 +3050,7 @@ cdef int try_get_index(list values, object value, cbool* found):
 @wraparound(False)
 cdef size_t _load_job(str rmatsf, list vbams, list prep_counts_by_bam,
                       vector[unordered_map[string,vector[Triad]]]& novel_juncs,
-                      vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                      vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                       vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs,
                       int mode):
     cdef:
@@ -3172,8 +3126,7 @@ cdef size_t _load_job(str rmatsf, list vbams, list prep_counts_by_bam,
                 for line in eles[1:]:
                     ele = [int(s) for s in line.split(',')]
                     tetrad.set(ele[0], ele[1], ele[2], ele[3])
-                    exons[idx][gene_id][tetrad].first = ele[4]
-                    exons[idx][gene_id][tetrad].second = ele[5]
+                    exons[idx][gene_id][tetrad] = ele[4]
 
         # processing junction reads
         for i in range(len(bams)):
@@ -3210,7 +3163,7 @@ cdef load_sg(str bams, list dot_rmats_paths,
         int num = 0, num_file = 0
         list vbams = bams.split(',')
         list prep_counts_by_bam
-        vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]] exons
+        vector[unordered_map[string,cmap[Tetrad,int]]] exons
         vector[unordered_map[string,cmap[vector[pair[long,long]],int]]] juncs
 
     num = len(vbams)
@@ -3356,7 +3309,7 @@ cdef dict split_sg_files_by_bam(str bams, str tmp_dir, str out_dir,
 @boundscheck(False)
 @wraparound(False)
 cdef vector[size_t] load_read(str bams, str fn,
-                              vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]]& exons,
+                              vector[unordered_map[string,cmap[Tetrad,int]]]& exons,
                               vector[unordered_map[string,cmap[vector[pair[long,long]],int]]]& juncs):
     cdef:
         int num = 0, num_file = 0
@@ -3384,7 +3337,7 @@ def run_pipe(args):
         unordered_map[string,Gene] genes
         unordered_map[string,SupInfo] supple
         vector[unordered_map[string,vector[Triad]]] novel_juncs
-        vector[unordered_map[string,cmap[Tetrad,pair[int,int]]]] exons
+        vector[unordered_map[string,cmap[Tetrad,int]]] exons
         vector[unordered_map[string,cmap[string,int]]] multis
         cset[SE_info] se,
         cset[MXE_info] mxe,
@@ -3437,7 +3390,7 @@ def run_pipe(args):
         start = time.time()
         count_occurrence(args.bams, dot_rmats_file_paths, args.od, se, mxe,
                          alt3, alt5, ri, sam1len, args.junctionLength/2,
-                         args.readLength, args.nthread, args.dt, args.stat)
+                         args.readLength, args.nthread, args.stat)
         print 'count:', time.time() - start
 
         shutil.rmtree(split_dot_rmats_dir_path)

--- a/tests/bam.py
+++ b/tests/bam.py
@@ -133,7 +133,9 @@ def set_read_pair_from_intervals(read_1,
                                  intervals_1,
                                  intervals_2,
                                  read_length,
-                                 clip_length=None):
+                                 clip_length=None,
+                                 is_reversed_1=False,
+                                 is_reversed_2=True):
     cigar_1 = list()
     remaining_length = read_length
     prev_end = None
@@ -165,7 +167,6 @@ def set_read_pair_from_intervals(read_1,
     read_1.start_coord = read_1_start
     read_1.cigar = _string_from_cigar_ops(cigar_1)
 
-    read_2.is_reversed = True
     read_2_start = None
     cigar_2 = list()
     remaining_length = read_length
@@ -203,6 +204,8 @@ def set_read_pair_from_intervals(read_1,
     read_2.cigar = _string_from_cigar_ops(cigar_2)
 
     read_1.template_len = (read_2_end - read_1_start) + 1
+    read_1.is_reversed = is_reversed_1
+    read_2.is_reversed = is_reversed_2
     make_read_pair(read_1, read_2)
     return None
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -66,7 +66,11 @@ class BaseTest(unittest.TestCase):
 
         self.assertEqual(err_lines, list())
 
-    def _create_gtf_from_transcripts(self, gtf_path, exons_by_transcript):
+    def _create_gtf_from_transcripts(self,
+                                     gtf_path,
+                                     exons_by_transcript,
+                                     genes=None,
+                                     strands=None):
         gtf = tests.gtf.GTF()
         gtf.path = gtf_path
 
@@ -74,9 +78,17 @@ class BaseTest(unittest.TestCase):
         for i, exons_for_transcript in enumerate(exons_by_transcript):
             transcript = tests.gtf.Transcript()
             transcript.chromosome = '1'
-            transcript.strand = '+'
-            transcript.gene_id = tests.util.gene_id_str(1)
-            transcript.gene_name = tests.util.gene_name_str(1)
+            strand_i = '+'
+            if strands is not None:
+                strand_i = strands[i]
+
+            transcript.strand = strand_i
+            gene_i = 1
+            if genes is not None:
+                gene_i = genes[i]
+
+            transcript.gene_id = tests.util.gene_id_str(gene_i)
+            transcript.gene_name = tests.util.gene_name_str(gene_i)
             transcript.transcript_id = tests.util.transcript_id_str(i)
             transcript.exons = exons_for_transcript
             transcripts.append(transcript)
@@ -91,7 +103,9 @@ class BaseTest(unittest.TestCase):
                                             chromosome_length,
                                             read_length,
                                             paired_read_coords,
-                                            clip_length=None):
+                                            clip_length=None,
+                                            is_reversed_1=False,
+                                            is_reversed_2=True):
         bam = tests.bam.BAM()
         bam.path = bam_path
 
@@ -109,7 +123,9 @@ class BaseTest(unittest.TestCase):
                 read_1_coords,
                 read_2_coords,
                 read_length,
-                clip_length=clip_length)
+                clip_length=clip_length,
+                is_reversed_1=is_reversed_1,
+                is_reversed_2=is_reversed_2)
             self.assertFalse(error)
             bam_reads.extend([paired_read_1, paired_read_2])
 

--- a/tests/output_parser.py
+++ b/tests/output_parser.py
@@ -110,14 +110,14 @@ def _parse_novel_junc(novel_junc_str):
 
 
 def _parse_exons(exon_str):
-    exon_ints, error = _parse_n_separated_ints(6, ',', exon_str)
+    exon_ints, error = _parse_n_separated_ints(5, ',', exon_str)
     if error:
         return None, error
 
     return {
         'start_box': exon_ints[0:2],
         'end_box': exon_ints[2:4],
-        'counts': exon_ints[4:6]
+        'count': exon_ints[4]
     }, None
 
 

--- a/tests/prep_post/test.py
+++ b/tests/prep_post/test.py
@@ -470,7 +470,7 @@ class Test(tests.base_test.BaseTest):
                     quoted_test_gene_id: [{
                         'start_box': [401, 499],
                         'end_box': [401, 499],
-                        'counts': [1, 0]
+                        'count': 1
                     }]
                 }])
             else:
@@ -478,7 +478,7 @@ class Test(tests.base_test.BaseTest):
                     quoted_test_gene_id: [{
                         'start_box': [1, 99],
                         'end_box': [1, 99],
-                        'counts': [1, 0]
+                        'count': 1
                     }]
                 }])
 
@@ -536,7 +536,7 @@ class Test(tests.base_test.BaseTest):
                     quoted_test_gene_id: [{
                         'start_box': [401, 499],
                         'end_box': [401, 499],
-                        'counts': [1, 0]
+                        'count': 1
                     }]
                 }])
             else:
@@ -544,7 +544,7 @@ class Test(tests.base_test.BaseTest):
                     quoted_test_gene_id: [{
                         'start_box': [1, 99],
                         'end_box': [1, 99],
-                        'counts': [1, 0]
+                        'count': 1
                     }]
                 }])
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -10,6 +10,7 @@ import tests.prep_post.test as prep_post_test
 import tests.retained_intron_novel.test as retained_intron_novel_test
 import tests.skipped_exon_basic.test as skipped_exon_basic_test
 import tests.skipped_exon_novel.test as skipped_exon_novel_test
+import tests.stranded.test as stranded_test
 import tests.task_stat.test as task_stat_test
 import tests.variable_read_length.test as variable_read_length_test
 
@@ -30,6 +31,7 @@ def build_test_suite():
     suite.addTest(loader.loadTestsFromModule(retained_intron_novel_test))
     suite.addTest(loader.loadTestsFromModule(skipped_exon_basic_test))
     suite.addTest(loader.loadTestsFromModule(skipped_exon_novel_test))
+    suite.addTest(loader.loadTestsFromModule(stranded_test))
     suite.addTest(loader.loadTestsFromModule(task_stat_test))
     suite.addTest(loader.loadTestsFromModule(variable_read_length_test))
     return suite

--- a/tests/stranded/.gitignore
+++ b/tests/stranded/.gitignore
@@ -1,0 +1,3 @@
+/first_strand/
+/second_strand/
+/unstranded/

--- a/tests/stranded/test.py
+++ b/tests/stranded/test.py
@@ -1,0 +1,294 @@
+import os.path
+import unittest
+
+import tests.base_test
+import tests.output_parser as output_parser
+import tests.test_config
+import tests.util
+
+
+class StrandedBaseTest(tests.base_test.BaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self._test_base_dir = tests.test_config.TEST_BASE_DIR
+        self._test_dir = os.path.join(self._test_base_dir, 'stranded',
+                                      self._sub_test_name())
+        self._generated_input_dir = os.path.join(self._test_dir,
+                                                 'generated_input')
+        self._out_dir = os.path.join(self._test_dir, 'out')
+        self._tmp_dir = os.path.join(self._test_dir, 'tmp')
+        tests.util.recreate_dirs([
+            self._generated_input_dir, self._out_dir, self._tmp_dir,
+            self._command_output_dir()
+        ])
+
+        self._read_type = 'paired'
+        self._read_length = 50
+        self._chromosome_length = 2000
+        self._task = 'both'
+
+        self._sample_1_bams_path = os.path.join(self._generated_input_dir,
+                                                'b1.txt')
+        sample_1_bam_replicate_template = os.path.join(
+            self._generated_input_dir, 'sample_1_rep_{}.bam')
+        self._sample_1_bams = self._create_sample_1_bams(
+            self._sample_1_bams_path, sample_1_bam_replicate_template)
+
+        self._gtf_path = os.path.join(self._generated_input_dir, 'test.gtf')
+        transcript_exons, transcript_genes, transcript_strands = (
+            self._exons_genes_and_strands_by_transcript())
+        self._gtf = self._create_gtf_from_transcripts(
+            self._gtf_path,
+            transcript_exons,
+            genes=transcript_genes,
+            strands=transcript_strands)
+
+    def _command_output_dir(self):
+        return os.path.join(self._test_dir, 'command_output')
+
+    def _rmats_arguments(self):
+        return [
+            '--b1',
+            self._sample_1_bams_path,
+            '--gtf',
+            self._gtf_path,
+            '--od',
+            self._out_dir,
+            '-t',
+            self._read_type,
+            '--readLength',
+            str(self._read_length),
+            '--tmp',
+            self._tmp_dir,
+            '--task',
+            self._task,
+            '--statoff',
+        ]
+
+    def _create_sample_1_bams(self, sample_1_bams_path,
+                              sample_1_replicate_template):
+        rep_1_bam_path = sample_1_replicate_template.format(1)
+        rep_1_bam = self._create_bam_from_paired_read_coords(
+            rep_1_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_1_1(),
+            is_reversed_1=False,
+            is_reversed_2=True)
+
+        rep_2_bam_path = sample_1_replicate_template.format(2)
+        rep_2_bam = self._create_bam_from_paired_read_coords(
+            rep_2_bam_path,
+            self._chromosome_length,
+            self._read_length,
+            self._paired_read_coords_1_2(),
+            is_reversed_1=True,
+            is_reversed_2=False)
+
+        sample_1_bams = [rep_1_bam, rep_2_bam]
+        self._write_bams(sample_1_bams, sample_1_bams_path)
+        return sample_1_bams
+
+    def _exons_genes_and_strands_by_transcript(self):
+        exons_genes_and_strands = [
+            # SE gene 1 + strand
+            ([(1, 100), (201, 300), (401, 500)], [1], ['+']),
+            ([(1, 100), (401, 500)], [1], ['+']),
+            # SE gene 2 - strand
+            ([(1001, 1100), (1201, 1300), (1401, 1500)], [2], ['-']),
+            ([(1001, 1100), (1401, 1500)], [2], ['-']),
+        ]
+        exons_by_transcript = list()
+        genes_by_transcript = list()
+        strands_by_transcript = list()
+        for exons, genes, strands in exons_genes_and_strands:
+            for gene in genes:
+                for strand in strands:
+                    exons_by_transcript.append(exons)
+                    genes_by_transcript.append(gene)
+                    strands_by_transcript.append(strand)
+
+        return exons_by_transcript, genes_by_transcript, strands_by_transcript
+
+    def _include_read_1(self):
+        return ([[81, 100], [201, 300]], [[201, 300]])
+
+    def _skip_read_1(self):
+        return ([[81, 100], [401, 500]], [[401, 500]])
+
+    def _include_read_2(self):
+        return ([[1081, 1100], [1201, 1300]], [[1201, 1300]])
+
+    def _skip_read_2(self):
+        return ([[1081, 1100], [1401, 1500]], [[1401, 1500]])
+
+    def _paired_read_coords_1_1(self):
+        return [
+            self._include_read_1(),
+            self._skip_read_1(),
+            self._include_read_2(),
+            self._skip_read_2(),
+        ]
+
+    def _paired_read_coords_1_2(self):
+        return [
+            self._include_read_1(),
+            self._skip_read_1(),
+            self._include_read_2(),
+            self._skip_read_2(),
+        ]
+
+
+class FirstStrandTest(StrandedBaseTest):
+    def _sub_test_name(self):
+        return 'first_strand'
+
+    def test(self):
+        self._run_test()
+
+    def _rmats_arguments(self):
+        arguments = super()._rmats_arguments()
+        arguments.extend(['--libType', 'fr-firststrand'])
+        return arguments
+
+    def _check_results(self):
+        self._check_no_error_results()
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 2)
+        for row in se_mats_jc_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['SJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['strand'], '-')
+
+        se_mats_jcec_path = os.path.join(self._out_dir, 'SE.MATS.JCEC.txt')
+        se_mats_jcec_header, se_mats_jcec_rows, error = (
+            output_parser.parse_mats_jcec(se_mats_jcec_path))
+        self.assertFalse(error)
+        self._check_se_mats_jcec_header(se_mats_jcec_header)
+        self.assertEqual(len(se_mats_jcec_rows), 2)
+        for row in se_mats_jcec_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '0,2')
+                self.assertEqual(row['SJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '2,0')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['strand'], '-')
+
+
+class SecondStrandTest(StrandedBaseTest):
+    def _sub_test_name(self):
+        return 'second_strand'
+
+    def test(self):
+        self._run_test()
+
+    def _rmats_arguments(self):
+        arguments = super()._rmats_arguments()
+        arguments.extend(['--libType', 'fr-secondstrand'])
+        return arguments
+
+    def _check_results(self):
+        self._check_no_error_results()
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 2)
+        for row in se_mats_jc_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['SJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['strand'], '-')
+
+        se_mats_jcec_path = os.path.join(self._out_dir, 'SE.MATS.JCEC.txt')
+        se_mats_jcec_header, se_mats_jcec_rows, error = (
+            output_parser.parse_mats_jcec(se_mats_jcec_path))
+        self.assertFalse(error)
+        self._check_se_mats_jcec_header(se_mats_jcec_header)
+        self.assertEqual(len(se_mats_jcec_rows), 2)
+        for row in se_mats_jcec_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '2,0')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,0')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '0,2')
+                self.assertEqual(row['SJC_SAMPLE_1'], '0,1')
+                self.assertEqual(row['strand'], '-')
+
+
+class UnstrandedTest(StrandedBaseTest):
+    def _sub_test_name(self):
+        return 'unstranded'
+
+    def test(self):
+        self._run_test()
+
+    def _rmats_arguments(self):
+        arguments = super()._rmats_arguments()
+        arguments.extend(['--libType', 'fr-unstranded'])
+        return arguments
+
+    def _check_results(self):
+        self._check_no_error_results()
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 2)
+        for row in se_mats_jc_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['strand'], '-')
+
+        se_mats_jcec_path = os.path.join(self._out_dir, 'SE.MATS.JCEC.txt')
+        se_mats_jcec_header, se_mats_jcec_rows, error = (
+            output_parser.parse_mats_jcec(se_mats_jcec_path))
+        self.assertFalse(error)
+        self._check_se_mats_jcec_header(se_mats_jcec_header)
+        self.assertEqual(len(se_mats_jcec_rows), 2)
+        for row in se_mats_jcec_rows:
+            self.assertIn(row['exonStart_0base'], ['200', '1200'])
+            if row['exonStart_0base'] == '200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '2,2')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['strand'], '+')
+            elif row['exonStart_0base'] == '1200':
+                self.assertEqual(row['IJC_SAMPLE_1'], '2,2')
+                self.assertEqual(row['SJC_SAMPLE_1'], '1,1')
+                self.assertEqual(row['strand'], '-')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
* Only record reads that match the gene strand
* Update read/write of .rmats to remove count by strand

Addresses https://github.com/Xinglab/rmats-turbo/issues/80