### PR TITLE
Remove buffer size limits in statistical model

### DIFF
--- a/rMATS_C/include/global.h
+++ b/rMATS_C/include/global.h
@@ -4,17 +4,9 @@
 
 # define __inline__     __inline__      __attribute__((always_inline))
 
-
-#define TITLE_LEN 1024
-#define MAX_LINE 10240
-#define MAX_CHAR 1024
-
-
 #define SIXTY 60
 #define nmax 1024
 #define mmax 10
-#define TITLE_ELEMENT_LEN 128
-#define COLUMN_LEN 8192
 #define LEN_OF_NT 1
 
 

--- a/rMATS_C/include/util.h
+++ b/rMATS_C/include/util.h
@@ -30,8 +30,8 @@ int parse_title(char* str, char** output);
 
 int str_to_vector(char* str, gsl_vector** vec);
 
-int parse_line(char* str, char* id, gsl_vector** inc1, gsl_vector** skp1,
-               gsl_vector** inc2, gsl_vector** skp2,
+int parse_line(char* str, char** id, size_t* id_n, gsl_vector** inc1,
+               gsl_vector** skp1, gsl_vector** inc2, gsl_vector** skp2,
                int* inclu_len, int* skip_len);
 
 int parse_file(const char* filename, diff_list_node* list, char** title);

--- a/rMATS_C/src/main.c
+++ b/rMATS_C/src/main.c
@@ -21,9 +21,10 @@ clock_t dur = 0;
 
 
 int main(int argc, char *argv[]) {
-    char *inputf = "input.txt", *outputf = (char*)malloc(sizeof(char)*MAX_CHAR);
-    char str_line[MAX_LINE], *title_element_list[100];
+    char *inputf = "input.txt", *outputf = NULL;
+    char *str_line = NULL, *title_element_list[100];
     int nthread = 1, opt, row_num = 0, i = 0;
+    size_t str_line_n = 0;
 
     while ((opt = getopt(argc, argv, "t:bc:o:i:")) != -1) {
         switch (opt) {
@@ -37,9 +38,8 @@ int main(int argc, char *argv[]) {
             cutoff = atof(optarg);
             break;
         case 'o':
-            // strcpy(outputf, optarg);
-            // strcat(outputf, "/rMATS_Result_P.txt");
-            outputf = optarg;
+            outputf = (char*)malloc(sizeof(char)*(strlen(optarg) + 1));
+            strcpy(outputf, optarg);
             break;
         case 'i':
             inputf = optarg;
@@ -94,23 +94,29 @@ int main(int argc, char *argv[]) {
 
     FILE *ifp = NULL, *ofp = NULL;
     if ((ifp = fopen(inputf, "r")) == NULL) {
-        printf("Fail to open %s!", inputf);
+        printf("Fail to open %s!\n", inputf);
         return -1;
     }
     if ((ofp = fopen(outputf, "w")) == NULL) {
-        printf("Fail to open %s!", outputf);
+        printf("Fail to open %s!\n", outputf);
         return -1;
     }
 
     // original comment: analyze the title of the inputed data file to find the
     //                   information of how much simulation are involved
-    fgets(str_line, MAX_LINE, ifp);
-    str_line[strlen(str_line)-1] = 0;
-    fprintf(ofp, "%s\tPValue\n", str_line);
+    if (getline(&str_line, &str_line_n, ifp) == -1) {
+        printf("Failed to read first line of input file\n");
+        return -1;
+    }
+    str_line[strlen(str_line)-1] = 0; // overwrite the old newline
+    fprintf(ofp, "%s\tPValue\n", str_line); // append PValue header to old headers
     for (i = 0; i < row_num; ++i) {
-        fgets(str_line, MAX_LINE, ifp);
-        str_line[strlen(str_line)-1] = 0;
-        fprintf(ofp, "%s\t%.12g\n", str_line, *prob[i]);
+        if (getline(&str_line, &str_line_n, ifp) == -1) {
+            printf("Failed to read row %d of input file\n", i);
+            return -1;
+        }
+        str_line[strlen(str_line)-1] = 0; // overwrite old newline
+        fprintf(ofp, "%s\t%.12g\n", str_line, *prob[i]); // append PValue
     }
     fclose(ifp);
     fclose(ofp);
@@ -118,6 +124,8 @@ int main(int argc, char *argv[]) {
     msec = dur * 1000 / CLOCKS_PER_SEC;
     printf("Time for func(single thread): %d seconds %d milliseconds\n", msec/1000, msec%1000);
 
+    free(str_line);
+    free(outputf);
     free(datum);
     free(prob);
     return 0;

--- a/rMATS_C/src/util.c
+++ b/rMATS_C/src/util.c
@@ -143,7 +143,7 @@ int parse_title(char* str, char** output) {
     int idx = 0;
     char *token = strtok(str, " \t\r\n\v\f");
     while(token) {
-        output[idx] = (char*)malloc(sizeof(char)*TITLE_ELEMENT_LEN);
+        output[idx] = (char*)malloc(sizeof(char)*(strlen(token) + 1));
         strcpy(output[idx++], token);
         token = strtok(NULL, " \t\r\n\v\f");
     }
@@ -192,15 +192,16 @@ int str_to_vector(char* input, gsl_vector** vec) {
 }
 
 
-int parse_line(char* str, char* id, gsl_vector** inc1, gsl_vector** skp1,
-               gsl_vector** inc2, gsl_vector** skp2,
+int parse_line(char* str, char** id, size_t* id_n, gsl_vector** inc1,
+               gsl_vector** skp1, gsl_vector** inc2, gsl_vector** skp2,
                int* inclu_len, int* skip_len) {
     int idx = 0;
-    char output[7][COLUMN_LEN];
+    size_t found_id_len = 0;
+    char *output[7];
 
     char *token = strtok(str, " \t\r\n\v\f");
     while(token) {
-        strcpy(output[idx++], token);
+        output[idx++] = token;
         token = strtok(NULL, " \t\r\n\v\f");
     }
 
@@ -209,12 +210,21 @@ int parse_line(char* str, char* id, gsl_vector** inc1, gsl_vector** skp1,
     //     base += idx? strlen(output[idx-1]) + LEN_OF_NT : 0;
     // } while(sscanf(str + base, "%s \t\n", output[idx++]) != EOF);
 
-    strcpy(id, output[0]);
+
+    found_id_len = strlen(output[0]);
+    if ((*id_n) <= found_id_len) {
+        *id_n = found_id_len + 1;
+        if ((*id) != NULL) {
+            free(*id);
+        }
+        *id = (char*)malloc(sizeof(char)*(*id_n));
+    }
+    strcpy(*id, output[0]);
     if (str_to_vector(output[1], inc1) == -1 ||
         str_to_vector(output[2], skp1) == -1 ||
         str_to_vector(output[3], inc2) == -1 ||
         str_to_vector(output[4], skp2) == -1) {
-        printf("An error occured. rMATS cannot handle missing value. Sample Id: %s\n", id);
+        printf("An error occured. rMATS cannot handle missing value. Sample Id: %s\n", *id);
         printf("Exiting.\n");
         exit(0);
         
@@ -228,9 +238,8 @@ int parse_line(char* str, char* id, gsl_vector** inc1, gsl_vector** skp1,
 
 int parse_file(const char* filename, diff_list_node* list, char** title_element_list) {
     FILE *ifp;
-    size_t olen = MAX_LINE;
-    char *str_line = (char*)malloc(sizeof(char)*olen);
-    char title[TITLE_LEN], id[MAX_LINE];
+    char *str_line = NULL, *id = NULL;
+    size_t str_line_n = 0, id_n = 0;
     int row_num=0, inclu_len, skip_len;
     gsl_vector *inc1 = NULL, *skp1 = NULL, *inc2 = NULL, *skp2 = NULL;
 
@@ -238,12 +247,16 @@ int parse_file(const char* filename, diff_list_node* list, char** title_element_
         printf("Fail to open!");
         return 0;
     }
-    fgets(title, TITLE_LEN, ifp);
-    parse_title(title, title_element_list);
+    if (getline(&str_line, &str_line_n, ifp) == -1) {
+        printf("Failed to read first line of input file.\n");
+        printf("Exiting\n");
+        exit(0);
+    }
+    parse_title(str_line, title_element_list);
 
-    while (getline(&str_line, &olen, ifp) != -1) {
+    while (getline(&str_line, &str_line_n, ifp) != -1) {
         ++row_num;
-        parse_line(str_line, id, &inc1, &skp1, &inc2, &skp2, &inclu_len, &skip_len);
+        parse_line(str_line, &id, &id_n, &inc1, &skp1, &inc2, &skp2, &inclu_len, &skip_len);
         if (inc1->size != skp1->size || inc2->size != skp2->size) {
             printf("An error occured. The length of the pair of vector should be equal. Sample Id: %s\n", id);
             printf("Size of vector: %ld, %ld, %ld, %ld\n", inc1->size, skp1->size, inc2->size, skp2->size);
@@ -268,7 +281,12 @@ int parse_file(const char* filename, diff_list_node* list, char** title_element_
             diff_append(list, diff_alloc(inc1, inc2, skp1, skp2, inclu_len, skip_len, 1, id));
         }
     }
-    free(str_line);
+    if (str_line != NULL) {
+        free(str_line);
+    }
+    if (id != NULL) {
+        free(id);
+    }
     fclose(ifp);
 
     return row_num;

--- a/rMATS_P/paste.py
+++ b/rMATS_P/paste.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-import csv
 import argparse
 
 
@@ -38,11 +37,10 @@ def main():
     with open(args.i, 'r') as ifp:
         with open(args.o1, 'w') as ofp1:
             with open(args.o2, 'w') as ofp2:
-                reader = csv.reader(ifp, delimiter='\t')
-                for line in reader:
-                    line = list(map(str, line))
-                    ofp1.write(line[0]+'\n')
-                    ofp2.write('\t'.join(line[1:])+'\n')
+                for line in ifp:
+                    columns = line.strip().split('\t')
+                    ofp1.write(columns[0]+'\n')
+                    ofp2.write('\t'.join(columns[1:])+'\n')
 
     return
 

--- a/rMATS_P/summary.py
+++ b/rMATS_P/summary.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-import csv
 import math
 import os.path
 import sys
@@ -68,8 +67,13 @@ def count_events(file_path, args):
     sig_sample_2_higher = 0
     if os.path.exists(file_path):
         with open(file_path, 'rt') as file_handle:
-            reader = csv.DictReader(file_handle, delimiter='\t')
-            for row in reader:
+            for line_i, line in enumerate(file_handle):
+                columns = line.strip().split('\t')
+                if line_i == 0:
+                    headers = columns
+                    continue
+
+                row = dict(zip(headers, columns))
                 total += 1
                 p_value = parse_float(row['PValue'])
                 fdr = parse_float(row['FDR'])

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -12,6 +12,7 @@ import tests.prep_post.test as prep_post_test
 import tests.retained_intron_novel.test as retained_intron_novel_test
 import tests.skipped_exon_basic.test as skipped_exon_basic_test
 import tests.skipped_exon_novel.test as skipped_exon_novel_test
+import tests.stat_large_file.test as stat_large_file_test
 import tests.stranded.test as stranded_test
 import tests.task_stat.test as task_stat_test
 import tests.variable_read_length.test as variable_read_length_test
@@ -35,6 +36,7 @@ def build_test_suite():
     suite.addTest(loader.loadTestsFromModule(retained_intron_novel_test))
     suite.addTest(loader.loadTestsFromModule(skipped_exon_basic_test))
     suite.addTest(loader.loadTestsFromModule(skipped_exon_novel_test))
+    suite.addTest(loader.loadTestsFromModule(stat_large_file_test))
     suite.addTest(loader.loadTestsFromModule(stranded_test))
     suite.addTest(loader.loadTestsFromModule(task_stat_test))
     suite.addTest(loader.loadTestsFromModule(variable_read_length_test))

--- a/tests/stat_large_file/.gitignore
+++ b/tests/stat_large_file/.gitignore
@@ -1,0 +1,4 @@
+/command_output/
+/generated_input/
+/out/
+/tmp/

--- a/tests/stat_large_file/test.py
+++ b/tests/stat_large_file/test.py
@@ -1,0 +1,196 @@
+import os.path
+import shutil
+import unittest
+
+import tests.base_test
+import tests.output_parser as output_parser
+import tests.test_config
+import tests.util
+
+
+class Test(tests.base_test.BaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self._test_base_dir = tests.test_config.TEST_BASE_DIR
+        self._test_dir = os.path.join(self._test_base_dir, 'stat_large_file')
+        self._generated_input_dir = os.path.join(self._test_dir,
+                                                 'generated_input')
+        self._out_dir = os.path.join(self._test_dir, 'out')
+        self._tmp_dir = os.path.join(self._test_dir, 'tmp')
+
+        tests.util.recreate_dirs([
+            self._generated_input_dir, self._out_dir, self._tmp_dir,
+            self._command_output_dir()
+        ])
+
+        self._gene_id = 'gene_id'
+        self._gene_symbol = 'gene_symbol'
+        self._chr = 'chr1'
+        self._strand = '+'
+        self._ids = [0, 1]
+        self._base_exon_coords = [300, 400, 100, 200, 500, 600]
+        self._num_sample_1_bams = int(1e4)
+        self._num_sample_2_bams = int(1e4)
+        self._inc_1_by_id = {0: 30, 1: 50}
+        self._skip_1_by_id = {0: 70, 1: 50}
+        self._inc_2_by_id = {0: 70, 1: 50}
+        self._skip_2_by_id = {0: 30, 1: 50}
+        self._inc_form_len = 200
+        self._skip_form_len = 100
+
+        self._from_gtf_se_path = os.path.join(self._generated_input_dir,
+                                              'fromGTF.SE.txt')
+        self._jc_raw_input_se_path = os.path.join(self._generated_input_dir,
+                                                  'JC.raw.input.SE.txt')
+        self._create_from_gtf(self._from_gtf_se_path)
+        self._create_jc_input(self._jc_raw_input_se_path)
+        shutil.copy(self._from_gtf_se_path, self._out_dir)
+        shutil.copy(self._jc_raw_input_se_path, self._out_dir)
+
+    def test(self):
+        self._run_test()
+
+    def _command_output_dir(self):
+        return os.path.join(self._test_dir, 'command_output')
+
+    def _rmats_arguments(self):
+        return [
+            '--od', self._out_dir, '--tmp', self._tmp_dir, '--task', 'stat'
+        ]
+
+    def _exon_coord_strs_for_i(self, i):
+        exon_coords = [(coord + (i * 1000))
+                       for coord in self._base_exon_coords]
+        return [str(x) for x in exon_coords]
+
+    def _write_tsv_line(self, handle, columns):
+        handle.write('{}\n'.format('\t'.join(columns)))
+
+    def _create_from_gtf(self, gtf_path):
+        headers = [
+            'ID', 'GeneID', 'geneSymbol', 'chr', 'strand', 'exonStart_0base',
+            'exonEnd', 'upstreamES', 'upstreamEE', 'downstreamES',
+            'downstreamEE'
+        ]
+        with open(gtf_path, 'wt') as handle:
+            self._write_tsv_line(handle, headers)
+            for i in self._ids:
+                exon_coord_strs = self._exon_coord_strs_for_i(i)
+                columns = [
+                    str(i), self._gene_id, self._gene_symbol, self._chr,
+                    self._strand
+                ]
+                columns.extend(exon_coord_strs)
+                self._write_tsv_line(handle, columns)
+
+    def _repeat_and_comma_separate(self, value, count):
+        return ','.join([str(value)] * count)
+
+    def _create_jc_input(self, jc_path):
+        headers = [
+            'ID', 'IJC_SAMPLE_1', 'SJC_SAMPLE_1', 'IJC_SAMPLE_2',
+            'SJC_SAMPLE_2', 'IncFormLen', 'SkipFormLen'
+        ]
+        with open(jc_path, 'wt') as handle:
+            self._write_tsv_line(handle, headers)
+            for i in self._ids:
+                inc_1 = self._inc_1_by_id[i]
+                skip_1 = self._skip_1_by_id[i]
+                inc_2 = self._inc_2_by_id[i]
+                skip_2 = self._skip_2_by_id[i]
+                inc_1_str = self._repeat_and_comma_separate(
+                    inc_1, self._num_sample_1_bams)
+                skip_1_str = self._repeat_and_comma_separate(
+                    skip_1, self._num_sample_1_bams)
+                inc_2_str = self._repeat_and_comma_separate(
+                    inc_2, self._num_sample_2_bams)
+                skip_2_str = self._repeat_and_comma_separate(
+                    skip_2, self._num_sample_2_bams)
+                columns = [
+                    str(i), inc_1_str, skip_1_str, inc_2_str, skip_2_str,
+                    str(self._inc_form_len),
+                    str(self._skip_form_len)
+                ]
+                self._write_tsv_line(handle, columns)
+
+    def _inc_level(self, inc, skip, inc_len, skip_len):
+        normed_inc = (inc / inc_len)
+        normed_skip = (skip / skip_len)
+        inc_level = normed_inc / (normed_inc + normed_skip)
+        return round(inc_level, 3)
+
+    def _check_results(self):
+        self.assertEqual(self._rmats_return_code, 0)
+        command_stderr_file_name = self._get_stderr_file_name()
+        with open(command_stderr_file_name, 'rt') as err_f_h:
+            err_lines = err_f_h.readlines()
+
+        # Only testing SE JC. Expect error line for SE JCEC and
+        # all MXE, A3SS, A5SS, RI
+        self.assertEqual(len(err_lines), 9)
+        for err_line in err_lines:
+            self.assertIn('Unable to produce final output files for', err_line)
+
+        se_mats_jc_path = os.path.join(self._out_dir, 'SE.MATS.JC.txt')
+        se_mats_jc_header, se_mats_jc_rows, error = output_parser.parse_mats_jc(
+            se_mats_jc_path)
+        self.assertFalse(error)
+        self._check_se_mats_jc_header(se_mats_jc_header)
+        self.assertEqual(len(se_mats_jc_rows), 2)
+        for row_i, row in enumerate(se_mats_jc_rows):
+            self.assertEqual(row['ID'], str(self._ids[row_i]))
+            self.assertEqual(row['GeneID'], self._gene_id)
+            self.assertEqual(row['geneSymbol'], self._gene_symbol)
+            self.assertEqual(row['chr'], self._chr)
+            self.assertEqual(row['strand'], self._strand)
+            exon_coord_strs = self._exon_coord_strs_for_i(row_i)
+            self.assertEqual(row['exonStart_0base'], exon_coord_strs[0])
+            self.assertEqual(row['exonEnd'], exon_coord_strs[1])
+            self.assertEqual(row['upstreamES'], exon_coord_strs[2])
+            self.assertEqual(row['upstreamEE'], exon_coord_strs[3])
+            self.assertEqual(row['downstreamES'], exon_coord_strs[4])
+            self.assertEqual(row['downstreamEE'], exon_coord_strs[5])
+            inc_1 = self._inc_1_by_id[row_i]
+            skip_1 = self._skip_1_by_id[row_i]
+            inc_2 = self._inc_2_by_id[row_i]
+            skip_2 = self._skip_2_by_id[row_i]
+            inc_1_str = self._repeat_and_comma_separate(
+                inc_1, self._num_sample_1_bams)
+            skip_1_str = self._repeat_and_comma_separate(
+                skip_1, self._num_sample_1_bams)
+            inc_2_str = self._repeat_and_comma_separate(
+                inc_2, self._num_sample_2_bams)
+            skip_2_str = self._repeat_and_comma_separate(
+                skip_2, self._num_sample_2_bams)
+            self.assertEqual(row['IJC_SAMPLE_1'], inc_1_str)
+            self.assertEqual(row['SJC_SAMPLE_1'], skip_1_str)
+            self.assertEqual(row['IJC_SAMPLE_2'], inc_2_str)
+            self.assertEqual(row['SJC_SAMPLE_2'], skip_2_str)
+            self.assertEqual(row['IncFormLen'], str(self._inc_form_len))
+            self.assertEqual(row['SkipFormLen'], str(self._skip_form_len))
+            inc_level_1 = self._inc_level(inc_1, skip_1, self._inc_form_len,
+                                          self._skip_form_len)
+            inc_level_2 = self._inc_level(inc_2, skip_2, self._inc_form_len,
+                                          self._skip_form_len)
+            inc_level_diff = inc_level_1 - inc_level_2
+            inc_level_diff = round(inc_level_diff, 3)
+            inc_level_1_str = self._repeat_and_comma_separate(
+                inc_level_1, self._num_sample_1_bams)
+            inc_level_2_str = self._repeat_and_comma_separate(
+                inc_level_2, self._num_sample_2_bams)
+            self.assertEqual(row['IncLevel1'], inc_level_1_str)
+            self.assertEqual(row['IncLevel2'], inc_level_2_str)
+            self.assertEqual(row['IncLevelDifference'], str(inc_level_diff))
+
+        row_0 = se_mats_jc_rows[0]
+        self.assertEqual(row_0['PValue'], '0')
+        self.assertEqual(row_0['FDR'], '0.0')
+
+        row_1 = se_mats_jc_rows[1]
+        self.assertEqual(row_1['PValue'], '1')
+        self.assertEqual(row_1['FDR'], '1.0')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
* dynamically allocate memory with malloc and getline
* do not use the csv module because it has a field size limit

Addresses this issue: https://github.com/Xinglab/rmats-turbo/issues/139