### PR TITLE
Remove unused clock_t variable

### DIFF
--- a/rMATS_C/src/myfunc.c
+++ b/rMATS_C/src/myfunc.c
@@ -14,7 +14,6 @@
 
 extern double rho;
 extern double cutoff;
-extern clock_t dur;
 
 
 #define ITER_CUTOFF 0.01


### PR DESCRIPTION
That variable caused an error for the osx bioconda build of rmats
which used clang. The error was because the time.h header was not
included

https://github.com/bioconda/bioconda-recipes/pull/32119