### PR TITLE
Use .find rather than []

### DIFF
--- a/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
+++ b/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
@@ -828,6 +828,9 @@ cdef void parse_bam(long fidx, string bam,
 
             visited.clear()
             for i in range(mc/refer_len, mec/refer_len+1):
+                if geneGroup.find(i) == geneGroup.end():
+                    continue
+
                 cg = geneGroup[i].begin()
                 while cg != geneGroup[i].end():
                     ## for each candidate gene
@@ -866,6 +869,9 @@ cdef void parse_bam(long fidx, string bam,
                     continue
 
                 for j in range(estart/refer_len, eend/refer_len+1):
+                    if geneGroup.find(j) == geneGroup.end():
+                        continue
+
                     cg = geneGroup[j].begin()
                     while cg != geneGroup[j].end():
                         ## for each candidate gene


### PR DESCRIPTION
`geneGroup[i]` would insert a default value if `i` was not already in `geneGroup`. If that happened while multiple threads were accessing `geneGroup` then it could lead to a segfault. Instead use `.find` to check for a value before using `[]`

Addresses: https://github.com/Xinglab/rmats-turbo/issues/18