### PR TITLE
Handle exceptions when reading the gtf file

### DIFF
--- a/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
+++ b/rMATS_pipeline/rmatspipeline/rmatspipeline.pyx
@@ -95,7 +95,7 @@ cdef:
 @wraparound(False)
 cdef void parse_gtf(str gtff, unordered_map[int,cset[string]]& geneGroup,
                     unordered_map[string,Gene]& genes,
-                    unordered_map[string,SupInfo]& supple):
+                    unordered_map[string,SupInfo]& supple) except *:
     """TODO: Docstring for parse_gtf.
     :returns: TODO
 
@@ -3837,7 +3837,14 @@ def run_pipe(args):
         int jld2
 
     start = time.time()
-    parse_gtf(args.gtf, geneGroup, genes, supple)
+    try:
+        parse_gtf(args.gtf, geneGroup, genes, supple)
+    except Exception:
+        print('unable to parse the gtf: {}'.format(args.gtf))
+        print('please check that the --gtf argument is a valid'
+              ' .gtf file that is not compressed')
+        raise
+
     print 'gtf:', time.time() - start
 
     start = time.time()


### PR DESCRIPTION
* print a helpful error message

The new error message is:
```
unable to parse the gtf: /path/to/filename.gtf.gz
please check that the --gtf argument is a valid .gtf file that is not compressed
Traceback (most recent call last):
  File "/scr1/users/kutscherae/rmats-turbo/rmats.py", line 595, in <module>
    main()
  File "/scr1/users/kutscherae/rmats-turbo/rmats.py", line 563, in main
    run_pipe(args)
  File "rmatspipeline/rmatspipeline.pyx", line 3846, in rmats.rmatspipeline.run_pipe
  File "rmatspipeline/rmatspipeline.pyx", line 3841, in rmats.rmatspipeline.run_pipe
  File "rmatspipeline/rmatspipeline.pyx", line 114, in genexpr
  File "rmatspipeline/rmatspipeline.pyx", line 114, in genexpr
  File "/scr1/users/kutscherae/rmats-turbo/conda_envs/rmats/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```
And the program exits with that error

The old error message was:
```
Traceback (most recent call last):
  File "rmatspipeline/rmatspipeline.pyx", line 114, in genexpr
  File "/scr1/users/kutscherae/rmats-turbo/conda_envs/rmats/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
Exception ignored in: 'rmats.rmatspipeline.parse_gtf'
Traceback (most recent call last):    
  File "rmatspipeline/rmatspipeline.pyx", line 114, in genexpr
  File "/scr1/users/kutscherae/rmats-turbo/conda_envs/rmats/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```
Then it would go on to finish and print: `Done processing count files`, but the output would be empty