### PR TITLE
Add EventTypeDescription column to summary output

### DIFF
--- a/rMATS_P/summary.py
+++ b/rMATS_P/summary.py
@@ -100,7 +100,8 @@ def count_events(file_path, args):
 
 def summarize(args, output_file_handle):
     headers = [
-        'EventType', 'TotalEventsJC', 'TotalEventsJCEC', 'SignificantEventsJC',
+        'EventType', 'EventTypeDescription', 'TotalEventsJC',
+        'TotalEventsJCEC', 'SignificantEventsJC',
         'SigEventsJCSample1HigherInclusion',
         'SigEventsJCSample2HigherInclusion', 'SignificantEventsJCEC',
         'SigEventsJCECSample1HigherInclusion',
@@ -108,7 +109,15 @@ def summarize(args, output_file_handle):
     ]
 
     print('\t'.join(headers), file=output_file_handle)
+    event_types = {
+        'SE': 'skipped exon',
+        'A5SS': "alternative 5' splice site",
+        'A3SS': "alternative 3' splice site",
+        'MXE': 'mutually exclusive exons',
+        'RI': 'retained intron'
+    }
     for event in ['SE', 'A5SS', 'A3SS', 'MXE', 'RI']:
+        description = event_types[event]
         jc_path = os.path.join(args.output_dir, '{}.MATS.JC.txt'.format(event))
         jcec_path = os.path.join(args.output_dir,
                                  '{}.MATS.JCEC.txt'.format(event))
@@ -118,7 +127,7 @@ def summarize(args, output_file_handle):
         jcec_total = jcec_event_counts['total']
 
         values = [
-            event, jc_total, jcec_total, jc_event_counts['sig'],
+            event, description, jc_total, jcec_total, jc_event_counts['sig'],
             jc_event_counts['sig_sample_1_higher'],
             jc_event_counts['sig_sample_2_higher'], jcec_event_counts['sig'],
             jcec_event_counts['sig_sample_1_higher'],


### PR DESCRIPTION
The new summary.txt format is:
```
EventType	EventTypeDescription	TotalEventsJC	TotalEventsJCEC	SignificantEventsJC	SigEventsJCSample1HigherInclusion	SigEventsJCSample2HigherInclusion	SignificantEventsJCEC	SigEventsJCECSample1HigherInclusion	SigEventsJCECSample2HigherInclusion
SE	skipped exon	0	0	0	0	0	0	0	0
A5SS	alternative 5' splice site	0	0	0	0	0	0	0	0
A3SS	alternative 3' splice site	0	0	0	0	0	0	0	0
MXE	mutually exclusive exons	0	0	0	0	0	0	0	0
RI	retained intron	0	0	0	0	0	0	0	0
```

The old summary.txt format was:
```
EventType	TotalEventsJC	TotalEventsJCEC	SignificantEventsJC	SigEventsJCSample1HigherInclusion	SigEventsJCSample2HigherInclusion	SignificantEventsJCEC	SigEventsJCECSample1HigherInclusion	SigEventsJCECSample2HigherInclusion
SE	0	0	0	0	0	0	0	0
A5SS	0	0	0	0	0	0	0	0
A3SS	0	0	0	0	0	0	0	0
MXE	0	0	0	0	0	0	0	0
RI	0	0	0	0	0	0	0	0
```