### PR TITLE
Replace uses of make_pair with just pair

### DIFF
--- a/bamtools/src/toolkit/bamtools_resolve.cpp
+++ b/bamtools/src/toolkit/bamtools_resolve.cpp
@@ -410,7 +410,7 @@ bool ResolveTool::ReadNamesFileReader::Read(map<string, ReadGroupResolver>& read
         ReadGroupResolver& resolver = (*rgIter).second;
 
         // store read name with resolver
-        resolver.ReadNames.insert( make_pair<string,bool>(fields[1], true) ) ;
+        resolver.ReadNames.insert( pair<string,bool>(fields[1], true) ) ;
     }
 
     // if here, return success
@@ -607,7 +607,7 @@ bool ResolveTool::StatsFileReader::ParseReadGroupLine(const string& line,
     resolver.IsAmbiguous = ( fields.at(6) == TRUE_KEYWORD );
 
     // store RG entry and return success
-    readGroups.insert( make_pair<string, ReadGroupResolver>(name, resolver) );
+    readGroups.insert( pair<string, ReadGroupResolver>(name, resolver) );
     return true;
 }
 
@@ -1014,7 +1014,7 @@ bool ResolveTool::ResolveToolPrivate::MakeStats(void) {
         }
 
         // if read name not found, store new entry
-        else resolver.ReadNames.insert( make_pair<string, bool>(al.Name, isCurrentMateUnique) );
+        else resolver.ReadNames.insert( pair<string, bool>(al.Name, isCurrentMateUnique) );
     }
 
     // close files
@@ -1046,7 +1046,7 @@ void ResolveTool::ResolveToolPrivate::ParseHeader(const SamHeader& header) {
     SamReadGroupConstIterator rgEnd  = header.ReadGroups.ConstEnd();
     for ( ; rgIter != rgEnd; ++rgIter ) {
         const SamReadGroup& rg = (*rgIter);
-        m_readGroups.insert( make_pair<string, ReadGroupResolver>(rg.ID, ReadGroupResolver()) );
+        m_readGroups.insert( pair<string, ReadGroupResolver>(rg.ID, ReadGroupResolver()) );
     }
 }
 


### PR DESCRIPTION
* This supports compiling with llvm libcxx>=16.0.0
* c++03 definition was removed in https://github.com/llvm/llvm-project/commit/e0b3356e67a9288accab0f079963397a4421923c
* From the review for that change: https://reviews.llvm.org/D133013
  + this one does changes our C++03 API [...] I think it's fine to drop this. And it only reinforces my desire to get a discussion started on deprecating C++03 support entirely