### PR TITLE
Update dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ rMATS turbo is the C/Cython version of rMATS (refer to http://rnaseq-mats.source
 
 ## Dependencies
 
-Tested on Ubuntu (20.04 LTS)
-
-- Python (3.6.12 or 2.7.15)
-  * Cython (0.29.21 or 0.29.15 for Python 2)
+- Python (3.14.6)
+  * Cython (3.1.8)
+  * Setuptools (78.1.1)
 - BLAS, LAPACK
-- GNU Scientific Library (GSL 2.5)
-- GCC (>=5.4.0)
-- gfortran (Fortran 77)
-- CMake (3.15.4)
+- GNU Scientific Library (GSL 2.7)
+- GCC (15.3.0)
+- gfortran (15.3.0)
+- CMake (4.2.3)
 - [PAIRADISE](https://github.com/Xinglab/PAIRADISE) (optional)
 - [DARTS](https://github.com/Xinglab/DARTS) (optional)
 - Samtools (optional)
 - STAR (optional)
+
+Those versions were used during testing. Other versions may also be compatible
 
 ## Build
 
@@ -78,8 +79,6 @@ If rMATS was built with `./build_rmats --conda` then it should be run with:
 ```
 ./run_rmats {arguments}
 ```
-
-It takes about 30 minutes to install dependencies and build rMATS (as tested on an Ubuntu VM with 2 CPUs and 4 GB of memory)
 
 ## Test
 

--- a/bamtools/CMakeLists.txt
+++ b/bamtools/CMakeLists.txt
@@ -5,11 +5,11 @@
 # top-level
 # ==========================
 
+# Cmake requirements
+cmake_minimum_required( VERSION 3.5 )
+
 # set project name
 project( BamTools )
-
-# Cmake requirements
-cmake_minimum_required( VERSION 2.6.4 )
 
 # Force the build directory to be different from source directory
 macro( ENSURE_OUT_OF_SOURCE_BUILD MSG )

--- a/darts_model_conda_requirements.txt
+++ b/darts_model_conda_requirements.txt
@@ -1,6 +1,6 @@
-r-base=4.3.*
+r-base=4.5.*
 r-dosnow=1.0.*
 r-getopt=1.20.*
-r-ggplot2=3.4.*
+r-ggplot2=4.0.*
 r-mixtools=2.0.*
-r-rcpp=1.0.*
+r-rcpp=1.1.*

--- a/paired_model_conda_requirements.txt
+++ b/paired_model_conda_requirements.txt
@@ -1,5 +1,5 @@
-r-base=4.3.*
+r-base=4.5.*
 r-doparallel=1.0.*
 r-foreach=1.5.*
 r-iterators=1.0.*
-r-nloptr=2.0.*
+r-nloptr=2.2.*

--- a/python_conda_requirements.txt
+++ b/python_conda_requirements.txt
@@ -1,9 +1,9 @@
-Cython=3.0.*
-cmake=3.27.*
-gcc=13.*
-gfortran=13.*
+Cython=3.1.*
+cmake=4.2.*
+gcc=15.*
+gfortran=15.*
 gsl=2.7
-gxx=13.*
-liblapack=3.9.*
-python=3.10.*
-zlib=1.2.*
+gxx=15.*
+liblapack=3.11.*
+python=3.14.*
+zlib=1.3.*


### PR DESCRIPTION
* cmake 4 requires cmake_minimum_required to be at least 3.5